### PR TITLE
[BUG FIX] corrected missing lib. before get call line 445 in make_medium

### DIFF
--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -442,7 +442,7 @@ def make_generic_stack(thickness, temperature=273, ks=0, ka=0, effective_permitt
                                    temperature=lib.get(temperature, i, "temperature")
                                   )
 
-        sp.append(layer, get(interface, i))
+        sp.append(layer, lib.get(interface, i))
 
     return sp
 


### PR DESCRIPTION
Added a missing 'lib.' before 'get' statement at line 445 in make_medium that caused make_generic_stack(...) to fail when called.