### PR TITLE
Raise an error if ice density is calculated as negative

### DIFF
--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -479,6 +479,10 @@ def bulk_ice_density(temperature, salinity, porosity):
 
     # Density of mixture:
     rho = (1. - porosity) * (rho_ice * F1 / (F1 - rho_ice * salinity * PSU**-1 * F2)) * 1e3  # in kg/m3 (eq. 15, C&W, 1983)
+
+    if rho < 0:
+        raise SMRTError("Ice density may not be negative.")
+
     return rho
 
 

--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -234,7 +234,7 @@ def make_ice_column(ice_type,
     :param salinity: salinity of ice/water in kg/kg (see PSU constant in smrt module). Default is 0. If neither salinity nor brine_volume_fraction are given, the ice column is considered to consist of fresh water ice.
     :param brine_volume_fraction: brine / liquid water fraction in sea ice, optional parameter, if not given brine volume fraction is calculated from temperature and salinity in ~.smrt.permittivity.brine_volume_fraction
     :param density: density of ice layer in kg m :sup:`-3`
-    :param porosity: porosity of ice layer (in %). Default is 0. 
+    :param porosity: porosity of ice layer (0 - 1). Default is 0.
     :param add_water_substrate: Adds a substrate made of water below the ice column.
     Possible arguments are True (default) or False. If True looks for ice_type to determine if a saline or fresh water layer is added and/or uses the
     optional arguments 'water_temperature', 'water_salinity' of the water substrate.


### PR DESCRIPTION
Currently if the user supplies a porosity value of >1 to make_ice_column, it is passed to bulk_ice_density and a negative density is generated.

When SMRT is called to run, it throws an error because the imaginary part of the permittivity is negative.

This pull request generates an error within the bulk_ice_density function as soon as the density is recognised as negative. I've also changed the docs for make_ice_column to indicate that porosity should be 0-1 and not %.

I ran the test_make_medium.py script and all five tests were passed.