### PR TITLE
Liquid water content definition and H86 dry_snow_definition

### DIFF
--- a/smrt/permittivity/snow_mixing_formula.py
+++ b/smrt/permittivity/snow_mixing_formula.py
@@ -161,12 +161,13 @@ IEEE Trans. on Antennasand Propagation,Vol. 34, No. 11, 1329–1340, 1986. DOI: 
 
     """
 
+    # in this case liquid_water is the volume fraction of water wrt the snow (i.e., water / (ice+water+air))
+
     freqGHz = frequency * 1e-9
 
-    mass_melange = ((1 - liquid_water) * DENSITY_OF_ICE + liquid_water * DENSITY_OF_WATER)
+    mv = 100 * liquid_water # even if the definition in the paper is lwc
 
-    mv = 100 * density * liquid_water / mass_melange
-    dry_snow_density_gcm3 = 1e-3 * density * (1 - liquid_water) / (mass_melange / DENSITY_OF_ICE)
+    dry_snow_density_gcm3 = (1e-3 * density - liquid_water) / (1.0 - liquid_water)
 
     A1 = 0.78 + 0.03 * freqGHz - 0.58e-3 * freqGHz**2
     A2 = 0.97 - 0.39e-2 * freqGHz + 0.39e-3 * freqGHz**2


### PR DESCRIPTION
Dry snow density and liquid water content definitions have been changed according to the original paper. Results have been checked qualitatively against fig 3 (experimental data) and fig 7 and 8. Full reproduction was not possible but seem in line.

The definitions of liquid water content used in the paper is the "volume fraction of water". The same definition has been applied and tested also for PVS two phases and Debye-like model. Interestingly the PVS 2 and 3 phases models seems to provide similar results with this definition. For me it is the most understandable definition since by knowing the density it is possible to derive the ice and air content easily. I can help implementing this change for all the permittivity models already implemented in SMRT and also help with the conversion with the different units (e.g. mass fraction of water kg/kg).  

Note: even if differently stated i think that in eq 12a of the original manuscript the mv is expressed in %