### PR TITLE
Bug when only one param (tb_down) of SimpleIsotropicAtmosphere is specified as a dict of frequency. 

### DIFF
--- a/smrt/atmosphere/simple_isotropic_atmosphere.py
+++ b/smrt/atmosphere/simple_isotropic_atmosphere.py
@@ -58,7 +58,7 @@ class SimpleIsotropicAtmosphere(AtmosphereBase):
     def run(self, frequency, costheta, npol):
 
         def create_array(x):
-            if isinstance(self.constant_tbdown, dict):
+            if isinstance(x, dict):
                 x = x[frequency]
             return np.full(len(costheta) * npol, x)
 

--- a/smrt/atmosphere/test_atmosphere.py
+++ b/smrt/atmosphere/test_atmosphere.py
@@ -45,3 +45,16 @@ def test_frequency_dependent_atmosphere():
     assert np.all(atmos.run(frequency=10e9, costheta=mu, npol=2).tb_up == 5)
     assert np.all(atmos.run(frequency=21e9, costheta=mu, npol=2).tb_down == 23)
     assert np.all(atmos.run(frequency=21e9, costheta=mu, npol=2).transmittance == 0.95)
+
+def test_dict_param_atmosphere():
+    #test if one atmo param can be dict or other not specify (defaut)
+
+    mu = np.cos(np.arange(0, 90))
+    atmos = SimpleIsotropicAtmosphere(tb_down={10e9: 15, 21e9: 23})
+
+    assert np.all(atmos.run(frequency=21e9, costheta=mu, npol=2).tb_down == 23)
+    assert np.all(atmos.run(frequency=10e9, costheta=mu, npol=2).tb_down == 15)
+    assert np.all(atmos.run(frequency=21e9, costheta=mu, npol=2).tb_up == 0)
+    assert np.all(atmos.run(frequency=10e9, costheta=mu, npol=2).tb_up == 0)
+    assert np.all(atmos.run(frequency=21e9, costheta=mu, npol=2).transmittance == 1)
+    assert np.all(atmos.run(frequency=10e9, costheta=mu, npol=2).transmittance == 1)


### PR DESCRIPTION
I found this when only specifying tb_down and leaving other params (tb_up and transmittance) to default. A very specific case but useful for ground based radiometers.