### PR TITLE
Testing the changes advised on github to avoid lint errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ packages = ['smrt']
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-ignore = ["E741"]
+lint.ignore = ["E741"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"   # TODO: changed to google
 
 [tool.setuptools_scm]


### PR DESCRIPTION
These changes avoid a warning issued when testing "Lint with ruff" but they do not avoid the error.