### PR TITLE
Automatic google style conversion of the documentation

### DIFF
--- a/smrt/atmosphere/__init__.py
+++ b/smrt/atmosphere/__init__.py
@@ -2,6 +2,7 @@
 Contains different options to represent the atmosphere, that is the upper boundary conditions of the radiation transfer equation.
 
 Examples::
+
     from smrt.atmosphere.simple_isotropic_atmosphere import SimpleIsotropicAtmosphere
 
     atmosphere = SimpleIsotropicAtmosphere(tbdown=2.7, tbup=2.7, trans=0.998)

--- a/smrt/atmosphere/__init__.py
+++ b/smrt/atmosphere/__init__.py
@@ -1,8 +1,7 @@
-""" This package contains different options to represent the atmosphere, that is the upper boundary conditions 
-of the radiation transfer equation.
+"""
+Contains different options to represent the atmosphere, that is the upper boundary conditions of the radiation transfer equation.
 
-Example::
-
+Examples:
     from smrt.atmosphere.simple_isotropic_atmosphere import SimpleIsotropicAtmosphere
 
     atmosphere = SimpleIsotropicAtmosphere(tbdown=2.7, tbup=2.7, trans=0.998)

--- a/smrt/atmosphere/__init__.py
+++ b/smrt/atmosphere/__init__.py
@@ -1,7 +1,7 @@
 """
 Contains different options to represent the atmosphere, that is the upper boundary conditions of the radiation transfer equation.
 
-Examples:
+Examples::
     from smrt.atmosphere.simple_isotropic_atmosphere import SimpleIsotropicAtmosphere
 
     atmosphere = SimpleIsotropicAtmosphere(tbdown=2.7, tbup=2.7, trans=0.998)
@@ -9,4 +9,3 @@ Examples:
 The API is subject to change.
 
  """  # html documentation
- 

--- a/smrt/atmosphere/pyrtlib_atmosphere.py
+++ b/smrt/atmosphere/pyrtlib_atmosphere.py
@@ -49,16 +49,13 @@ https://satclop.github.io/pyrtlib/en/main/generated/pyrtlib.apiwebservices.ERA5R
     from smrt import make_atmosphere
 
     atmos = make_atmosphere('pyrtlib_era5_atmosphere', ncfile='era5_reanalysis-2023-05-16T18:00:00.nc',
-                                                       longitude=-75.07, latitude=123., date=datetime(2020, 2, 22, 12),
-                                                       absorption_model = 'R20')
+                            longitude=-75.07, latitude=123., date=datetime(2020, 2, 22, 12),
+                            absorption_model = 'R20')
 
 
 PyRTlib includes many absorption models and the list can be obtained using::
 
     PyRTlibAtmosphere.available_absorption_models()
-
-
-
 """
 
 # Stdlib import

--- a/smrt/atmosphere/pyrtlib_era5_atmosphere.py
+++ b/smrt/atmosphere/pyrtlib_era5_atmosphere.py
@@ -82,12 +82,14 @@ class PyRTlibERA5Atmosphere(PyRTlibAtmosphereBase):
 
 
 class _ERA5Reanalysis_with_grib(ERA5Reanalysis):
-    """temporary hack to retrieve ERA5 data in grib instead of netcdf which seems to be broken. The only disavantage is to require the dependency (cfgrib)
-"""
+    """
+    Temporary hack to retrieve ERA5 data in grib instead of netcdf which seems to be broken. The only disavantage is to require the dependency (cfgrib)
+    """
 
     @classmethod
     def read_data(cls, file: str, lonlat: tuple) -> pd.DataFrame:
-        """Read data from the ERA5 Reanalysis dataset.
+        """
+        Read data from the ERA5 Reanalysis dataset.
 
         Args:
             file (str): The netcdf file
@@ -179,7 +181,8 @@ class _ERA5Reanalysis_with_grib(ERA5Reanalysis):
                      lonlat: tuple,
                      resolution: Optional[float] = 0.25,
                      offset: Optional[float] = 0.4) -> str:
-        """Download ERA5Reanalysis data from the Copernicus Climate Change Service using the grib format as the netcdf
+        """
+        Download ERA5Reanalysis data from the Copernicus Climate Change Service using the grib format as the netcdf
         format seems to be broken at the moment (April 2024).
 
         Args:

--- a/smrt/atmosphere/simple_atmosphere.py
+++ b/smrt/atmosphere/simple_atmosphere.py
@@ -1,13 +1,14 @@
 # coding: utf-8
-"""Implement a one-layer atmosphere with prescribed frequency-dependent emission (up and down) and transmittance.
+"""
+Implements a one-layer atmosphere with prescribed frequency-dependent emission (up and down) and transmittance.
 
- TB and transmissivity are given as array of incidence and optional as frequency-dependent dictionnary.
+TB and transmissivity are given as array of incidence and optionally as frequency-dependent dictionary.
 
- In the current implementation, there are two constraints:
- - All the parametres (theta, tbub, tbdown and transmission) must be 1D list or arrays of the same length
- - the provided theta angles must cover the widest range possible in [0°, 90°] given that only interpolation is implemented at this stage.
-    When the RT solver calls this atmosphere, the requested cosines must be within the range of provided theta values.
-    Ideally 0° and 90° should be provided.
+In the current implementation, there are two constraints:
+- All the parameters (theta, tbub, tbdown and transmission) must be 1D list or arrays of the same length.
+- The provided theta angles must cover the widest range possible in [0°, 90°] given that only interpolation is implemented at this stage.
+  When the RT solver calls this atmosphere, the requested cosines must be within the range of provided theta values.
+  Ideally 0° and 90° should be provided.
 
  To make an atmosphere, it is recommended to use the helper function :py:func:`~smrt.inputs.make_model.make_atmosphere`.
 
@@ -19,7 +20,7 @@ Examples::
 
     # Incident dependent only
     atmos = make_atmosphere("simple_atmosphere", theta=[0, 40, 89], tb_down=[20., 25, 40], tb_up=[18., 23, 38],
-    transmittance=[0.95, 0.90, 0.80])
+                            transmittance=[0.95, 0.90, 0.80])
 
     # Frequency-dependent
     atmos = make_atmosphere("simple_atmosphere", theta={37e9: [10, 40, 90]}, tb_down={37e9: [20., 25, 40]}, tb_up={37e9: [18., 23, 38]})

--- a/smrt/atmosphere/simple_isotropic_atmosphere.py
+++ b/smrt/atmosphere/simple_isotropic_atmosphere.py
@@ -7,7 +7,8 @@ Implements an isotropic atmosphere with prescribed frequency-dependent emission 
  To make an atmosphere, it is recommended to use the helper function :py:func:`~smrt.inputs.make_model.make_atmosphere`.
 
 
-Examples:
+Examples::
+
     # The full path import is required
     from smrt import make_atmosphere
 

--- a/smrt/atmosphere/simple_isotropic_atmosphere.py
+++ b/smrt/atmosphere/simple_isotropic_atmosphere.py
@@ -1,14 +1,14 @@
 # coding: utf-8
-"""Implement an isotropic atmosphere with prescribed frequency-dependent emission (up and down) and transmittance.
+"""
+Implements an isotropic atmosphere with prescribed frequency-dependent emission (up and down) and transmittance.
 
  TB and transmissivity can be specified as a constant, or a frequency-dependent dictionary
 
  To make an atmosphere, it is recommended to use the helper function :py:func:`~smrt.inputs.make_model.make_atmosphere`.
 
 
-Examples::
-
-    # the full path import is required
+Examples:
+    # The full path import is required
     from smrt import make_atmosphere
 
     # Constant
@@ -16,7 +16,6 @@ Examples::
 
     # Frequency-dependent
     atmos = make_atmosphere("simple_isotopic_atmosphere", tb_down={10e9: 15.2, 21e9: 23.5})
-
 """
 
 # Stdlib import

--- a/smrt/atmosphere/simple_isotropic_atmosphere.py
+++ b/smrt/atmosphere/simple_isotropic_atmosphere.py
@@ -37,8 +37,13 @@ from ..core.atmosphere import AtmosphereBase, AtmosphereResult
 
 
 def make_atmosphere(tb_down=0, tb_up=0, transmittance=1):
-    """ Construct an atmosphere instance.
+    """
+    Construct an atmosphere instance.
 
+    Args:
+        tb_down:  (Default value = 0)
+        tb_up:  (Default value = 0)
+        transmittance:  (Default value = 1)
     """
     warn("""This function 'make_atmosphere' is going to be depreciated. Use smrt.inputs.make_medium.make_atmosphere or the
 short cut smrt.make_atmosphere instead.""", DeprecationWarning)

--- a/smrt/core/model.py
+++ b/smrt/core/model.py
@@ -161,7 +161,8 @@ def make_rtsolver(rtsolver_class: Union[str, Type], **options) -> Type:
     Returns:
         Type: This function provides an alternative to setting `rtsolver_options` in :py:func:`make_model`).
         
-        Example::
+    Example::
+
         make_model(..., make_rtsolver("dort", n_max_stream=128))
     """
     return lib.class_specializer('rtsolver', rtsolver_class, **options)
@@ -178,7 +179,8 @@ def make_emmodel(emmodel_class: Union[str, Type], **options) -> Type:
     Returns:
         Type: This function provides an alternative to setting `emmodel_options` in :py:func:`make_model`).
         
-        Example::
+    Example::
+    
         make_model(make_emmodel("iba", dense_snow_correction=True), ...)
     """
     return lib.class_specializer('emmodel', emmodel_class, **options)

--- a/smrt/emmodel/__init__.py
+++ b/smrt/emmodel/__init__.py
@@ -1,21 +1,21 @@
 """
-
 This package contains the different electromagnetic (EM) models that compute the scattering and absorption coefficients
-and the phase function in a _given_ _layer_. The computation of the inter-layer propagation is done by the
-:py:mod:`~smrt.rtsolver` package.
+and the phase function in a given layer. The computation of the inter-layer propagation is done by the
+`smrt.rtsolver` package.
 
 The EM models differ in many aspects, one of which is the constraint on the microstructure model
-they can be used with. The :py:mod:`smrt.emmodel.iba` model can use any
-microstructure model that defines autocorrelation functions (or its FT). In contrast  others such as
-:py:mod:`smrt.emmodel.dmrt_shortrange` is bound to the :py:mod:`smrt.microstructuremodel.sticky_hard_spheres` microstructure 
+they can be used with. The `smrt.emmodel.iba` model can use any
+microstructure model that defines autocorrelation functions (or its FT). In contrast, others such as
+`smrt.emmodel.dmrt_shortrange` are bound to the `smrt.microstructuremodel.sticky_hard_spheres` microstructure 
 for theoretical reasons.
 
-The selection of the EM model is done with the :py:func:`smrt.core.model.make_model` function
+The selection of the EM model is done with the `smrt.core.model.make_model` function.
 
-.. admonition::  **For developers**
+Note:
+    **For developers**
 
     To implement a new scattering formulation / phase function, we recommend to start from an existing module, probably rayleigh.py is the simplest.
-    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with :py:func:`~smrt.core.model.make_model` function as follows::
+    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with `smrt.core.model.make_model` function as follows:
 
         m = make_model("myscatteringtheory", "dort")
 
@@ -27,6 +27,5 @@ The selection of the EM model is done with the :py:func:`smrt.core.model.make_mo
         - ke() and effective_permittivity() methods
         - at least one of the phase and ft_even_phase methods (both is better).
 
-    For the details it is recommended to contact the authors as the calling arguments and required methods may change time to time.
-
- """
+    For the details it is recommended to contact the authors as the calling arguments and required methods may change from time to time.
+"""

--- a/smrt/emmodel/__init__.py
+++ b/smrt/emmodel/__init__.py
@@ -11,11 +11,10 @@ for theoretical reasons.
 
 The selection of the EM model is done with the :py:mod:`smrt.core.model.make_model` function.
 
-Note:
-    **For developers**
+Note:  **For developers**
 
     To implement a new scattering formulation / phase function, we recommend to start from an existing module, probably rayleigh.py is the simplest.
-    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with :py:mod:`smrt.core.model.make_model` function as follows:
+    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with :py:func:`smrt.core.model.make_model` function as follows::
 
         m = make_model("myscatteringtheory", "dort")
 

--- a/smrt/emmodel/__init__.py
+++ b/smrt/emmodel/__init__.py
@@ -4,18 +4,18 @@ and the phase function in a given layer. The computation of the inter-layer prop
 `smrt.rtsolver` package.
 
 The EM models differ in many aspects, one of which is the constraint on the microstructure model
-they can be used with. The `smrt.emmodel.iba` model can use any
+they can be used with. The:py:mod:`smrt.emmodel.iba` model can use any
 microstructure model that defines autocorrelation functions (or its FT). In contrast, others such as
-`smrt.emmodel.dmrt_shortrange` are bound to the `smrt.microstructuremodel.sticky_hard_spheres` microstructure 
+`smrt.emmodel.dmrt_shortrange` are bound to the:py:mod:`smrt.microstructuremodel.sticky_hard_spheres` microstructure 
 for theoretical reasons.
 
-The selection of the EM model is done with the `smrt.core.model.make_model` function.
+The selection of the EM model is done with the :py:mod:`smrt.core.model.make_model` function.
 
 Note:
     **For developers**
 
     To implement a new scattering formulation / phase function, we recommend to start from an existing module, probably rayleigh.py is the simplest.
-    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with `smrt.core.model.make_model` function as follows:
+    Copy this file to `myscatteringtheory.py` or any meaningful name. It can be directly used with :py:mod:`smrt.core.model.make_model` function as follows:
 
         m = make_model("myscatteringtheory", "dort")
 

--- a/smrt/emmodel/commontest.py
+++ b/smrt/emmodel/commontest.py
@@ -12,8 +12,8 @@ def test_energy_conservation(em, tolerance_pc, npol=None, subset=16):
     Args:
         em: the electromagnetic model that has been set up
         tolerance_pc: relative tolerance
-        npol:  (Default value = None)
-        subset:  (Default value = 16)
+        npol: (Default value = None)
+        subset: (Default value = 16)
     """
 
     # Default test is for 2 pol matrix

--- a/smrt/emmodel/commontest.py
+++ b/smrt/emmodel/commontest.py
@@ -6,11 +6,15 @@ import scipy.integrate
 
 # Generic test: check integral of phase function equals scattering coefficient
 def test_energy_conservation(em, tolerance_pc, npol=None, subset=16):
-    """test energy conservation
+    """
+    test energy conservation
 
-    :param em: the electromagnetic model that has been set up
-    :param tolerance_pc: relative tolerance
-"""
+    Args:
+        em: the electromagnetic model that has been set up
+        tolerance_pc: relative tolerance
+        npol:  (Default value = None)
+        subset:  (Default value = 16)
+    """
 
     # Default test is for 2 pol matrix
     if npol is None:

--- a/smrt/emmodel/iba.py
+++ b/smrt/emmodel/iba.py
@@ -51,14 +51,13 @@ class IBA(AdjustableEffectivePermittivityMixin,
     the size of the phase matrix as redundant information is not calculated for the
     passive case.
 
-    :param sensor: object containing sensor characteristics
-    :param layer: object containing snow layer characteristics (single layer)
-    :dense_snow_correction: set how snow denser than half the ice density (ie. fractional volume larger than 0.5 is handled).
-        "auto" means that snow is modeled as air bubble in ice instead of ice spheres in air. The default is None
+    Args:
+        sensor: Object containing sensor characteristics.
+        layer: Object containing snow layer characteristics (single layer).
+        dense_snow_correction: Set how snow denser than half the ice density (i.e. fractional volume larger than 0.5) is handled.
+            "auto" means that snow is modeled as air bubble in ice instead of ice spheres in air. The default is None.
 
-
-    **Usage Example:**
-
+    Example:
         This class is not normally accessed directly by the user, but forms part of the
         smrt model, together with the radiative solver (in this example, `dort`) i.e.:
 
@@ -67,8 +66,7 @@ class IBA(AdjustableEffectivePermittivityMixin,
             from smrt import make_model
             model = make_model("iba", "dort")
 
-        `iba` does not need to be imported by the user due to autoimport of electromagnetic model modules
-
+        `iba` does not need to be imported by the user due to autoimport of electromagnetic model modules.
     """
 
     # default effective_permittivity_model is polder_van_santen in Matzler 1998 and Matzler&Wiesman 1999
@@ -139,9 +137,9 @@ become a default in the future.""")
         return iba_coeff
 
     def mean_sq_field_ratio(self):
-        """ Mean squared field ratio calculation
+        """Mean squared field ratio calculation.
 
-        Uses layer effective permittivity
+        Uses layer effective permittivity.
 
         """
 
@@ -154,7 +152,13 @@ become a default in the future.""")
         pass
 
     def compute_ks(self):
-        """Calculate scattering coefficient: integrate p11+p12 over mu"""
+        """Calculate scattering coefficient.
+
+        Integrates p11+p12 over mu.
+
+        Returns:
+            float: Scattering coefficient.
+        """
 
         k = 6  # number of samples. This should be adaptative depending on the size/wavelength
         mu = np.linspace(1, -1, 2**k + 1)
@@ -163,7 +167,7 @@ become a default in the future.""")
         return ks_int / 4.  # Ding et al. (2010), normalised by (1/4pi)
 
     def ks_integrand(self, mu):
-        """ This is the scattering function for the IBA model.
+        """Scattering function for the IBA model.
 
         It uses the phase matrix in the 1-2 frame. With incident angle chosen to be 0, the scattering
         angle becomes the scattering zenith angle:
@@ -207,7 +211,7 @@ become a default in the future.""")
         return ks_int.real
 
     def phase(self, mu_s, mu_i, dphi, npol=2):
-        """ IBA Phase function(not decomposed).
+        """IBA Phase function (not decomposed).
 
 """
         p, sin_half_scatt = rayleigh_scattering_matrix_and_angle(mu_s, mu_i, dphi, npol)
@@ -225,15 +229,16 @@ become a default in the future.""")
         return smrt_matrix(ft_corr_fn * self.iba_coeff * p)
 
     def compute_ka(self):
-        """ IBA absorption coefficient calculated from the low-loss assumption of a general lossy medium.
+        """IBA absorption coefficient calculated from the low-loss assumption of a general lossy medium.
 
-        Calculates ka from wavenumber in free space(determined from sensor), and effective permittivity
-        of the medium(snow layer property): return ka: absorption coefficient[m:sup:`-1`]
+        Calculates ka from wavenumber in free space (determined from sensor), and effective permittivity
+        of the medium (snow layer property).
 
-        .. note::
+        Returns:
+            float: Absorption coefficient [m^-1].
 
-            This may not be suitable for high density material
-
+        Note:
+            This may not be suitable for high density material.
         """
 
         # after several go and back, the situation is now clear:

--- a/smrt/emmodel/iba_maxwell_garnett.py
+++ b/smrt/emmodel/iba_maxwell_garnett.py
@@ -26,28 +26,25 @@ class IBA_MaxwellGarnett(IBA):
     """
     Modified Improved Born Approximation electromagnetic model class.
 
-    As with all electromagnetic modules, this class is used to create an electromagnetic
-    object that holds information about the effective permittivity, extinction coefficient and
-    phase function for a particular snow layer. Due to the frequency dependence, information
-    about the sensor is required. Passive and active sensors also have different requirements on
-    the size of the phase matrix as redundant information is not calculated for the
-    passive case.
+    This class is used to create an electromagnetic object that holds information about the effective permittivity,
+    extinction coefficient and phase function for a particular snow layer. Due to the frequency dependence, information
+    about the sensor is required. Passive and active sensors also have different requirements on the size of the phase
+    matrix as redundant information is not calculated for the passive case.
 
-    :param sensor: object containing sensor characteristics
-    :param layer: object containing snow layer characteristics (single layer)
-
+    Args:
+        sensor: Object containing sensor characteristics.
+        layer: Object containing snow layer characteristics (single layer).
     """
     effective_permittivity_model = staticmethod(maxwell_garnett)
 
 
     def mean_sq_field_ratio(self):
-        """ Mean squared field ratio calculation
+        """Mean squared field ratio calculation.
 
-        Uses layer effective permittivity
+        Uses layer effective permittivity.
 
-        :param e0: background relative permittivity
-        :param eps: scattering constituent relative permittivity
-
+        Returns:
+            float: Mean squared field ratio.
         """
         apparent_permittivity = self.e0
         y2 = (1. / 3.) * np.sum(np.absolute(apparent_permittivity / (apparent_permittivity + (self.eps - self.e0) * self.depol_xyz))**2.)

--- a/smrt/emmodel/iba_original.py
+++ b/smrt/emmodel/iba_original.py
@@ -24,23 +24,22 @@ class IBA_original(IBA):
     the size of the phase matrix as redundant information is not calculated for the
     passive case.
 
-    :param sensor: object containing sensor characteristics
-    :param layer: object containing snow layer characteristics (single layer)
-
+    Args:
+        sensor: Object containing sensor characteristics.
+        layer: Object containing snow layer characteristics (single layer).
     """
 
     def compute_ka(self):
-        """ IBA absorption coefficient calculated from the low-loss assumption of a general lossy medium.
+        """IBA absorption coefficient calculated from the low-loss assumption of a general lossy medium.
 
         Calculates ka from wavenumber in free space (determined from sensor), and effective permittivity
-        of the medium (snow layer property)
+        of the medium (snow layer property).
 
-        :returns: absorption coefficient [m :sup:`-1`]
+        Returns:
+            float: Absorption coefficient [m^-1].
 
-        .. note::
-
-            This may not be suitable for high density material
-
+        Note:
+            This may not be suitable for high density material.
         """
 
         # equation from Matzler 1998 (original IBA98 paper) and Matzler and Wiesmann 1999

--- a/smrt/emmodel/nonscattering.py
+++ b/smrt/emmodel/nonscattering.py
@@ -18,8 +18,7 @@ from ..permittivity.generic_mixing_formula import polder_van_santen
 
 
 class NonScattering(IsotropicScatteringMixin):
-    """
-    """
+    """ """
 
     def __init__(self, sensor, layer):
 
@@ -43,10 +42,17 @@ class NonScattering(IsotropicScatteringMixin):
         pass
 
     def ft_even_phase(self, mu_s, mu_i, m_max, npol=None):
-        """ Non-scattering phase matrix.
+        """
+        Non-scattering phase matrix.
 
-        :returns: null phase matrix
+        Args:
+            mu_s: 
+            mu_i: 
+            m_max: 
+            npol:  (Default value = None)
 
+        Returns:
+            null phase matrix
         """
         if npol is None:
             npol = 2 if m_max == 0 else 3
@@ -54,10 +60,17 @@ class NonScattering(IsotropicScatteringMixin):
         return smrt_matrix.zeros((npol, npol, m_max + 1, len_atleast_1d(mu_s), len_atleast_1d(mu_i)))
 
     def phase(self, mu_s, mu_i, dphi, npol=2):
-        """Non-scattering phase matrix.
+        """
+        Non-scattering phase matrix.
 
-        :returns: null phase matrix
+        Args:
+            mu_s: 
+            mu_i: 
+            dphi: 
+            npol:  (Default value = 2)
 
+        Returns:
+            null phase matrix
         """
 
         return smrt_matrix.zeros((npol, npol, len_atleast_1d(dphi), len_atleast_1d(mu_s), len_atleast_1d(mu_i)))

--- a/smrt/emmodel/nonscattering.py
+++ b/smrt/emmodel/nonscattering.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
-"""Non-scattering medium can be applied to medium without heteoreneity (like water or pure ice layer).
-
+"""Non-scattering medium can be applied to medium without heterogeneity (like water or pure ice layer).
 """
 
 # Stdlib import

--- a/smrt/emmodel/prescribed_kskaeps.py
+++ b/smrt/emmodel/prescribed_kskaeps.py
@@ -1,17 +1,14 @@
 """Use prescribed scattering ks and absorption ka coefficients and effective permittivity in the layer.
-The phase matrix has the Rayleigh form with prescribed scattering coefficient
+The phase matrix has the Rayleigh form with prescribed scattering coefficient.
 
 This model is compatible with any microstructure but requires that ks, ka, and optionally effective permittivity to
-be set in the layer
+be set in the layer.
 
-
-Example::
-
+Example:
     m = make_model("prescribed_kskaeps", "dort")
     snowpack.layers[0].ks = ks
     snowpack.layers[0].ka = ka
     snowpack.layers[0].effective_permittivity = eff_eps
-
 """
 
 from .rayleigh import Rayleigh

--- a/smrt/emmodel/prescribed_kskaeps.py
+++ b/smrt/emmodel/prescribed_kskaeps.py
@@ -4,7 +4,8 @@ The phase matrix has the Rayleigh form with prescribed scattering coefficient.
 This model is compatible with any microstructure but requires that ks, ka, and optionally effective permittivity to
 be set in the layer.
 
-Example:
+Example::
+
     m = make_model("prescribed_kskaeps", "dort")
     snowpack.layers[0].ks = ks
     snowpack.layers[0].ka = ka

--- a/smrt/emmodel/sce_common.py
+++ b/smrt/emmodel/sce_common.py
@@ -1,4 +1,6 @@
-""" This is an abstract base class for the Strong Expansion theory and its various approximations. It is not to be used by the end-user."""
+"""This is an abstract base class for the Strong Expansion theory and its various approximations.
+It is not to be used by the end-user.
+"""
 
 # Stdlib import
 

--- a/smrt/emmodel/sce_common.py
+++ b/smrt/emmodel/sce_common.py
@@ -67,9 +67,7 @@ class SCEBase(IsotropicScatteringMixin, GenericFTPhaseMixin):
             return compute_A2_nonlocal(Q, microstructure)
 
     def compute_A2A2inv(self):
-        """ Compute A2 using equation 26
-
-        """
+        """Compute A2 using equation 26"""
 
         assert self.symmetrical
 
@@ -160,26 +158,27 @@ class SCEBase(IsotropicScatteringMixin, GenericFTPhaseMixin):
         return self._ks / (ks_int / 4.)  # Ding et al. (2010), normalised by (1/4pi)
 
     def ks_integrand(self, mu):
-        """ This is the scattering function for the IBA model.
-
+        """
+        This is the scattering function for the IBA model.
+        
         It uses the phase matrix in the 1-2 frame. With incident angle chosen to be 0, the scattering
         angle becomes the scattering zenith angle:
-
+        
         .. math::
-
+        
             \\Theta = \\theta
-
-
+        
+        
         Scattering coefficient is determined by integration over the scattering angle (0 to \\pi)
 
-        :param mu: cosine of the scattering angle (single angle)
-
+        Args:
+            mu: cosine of the scattering angle (single angle)
+        
         .. math::
-
-            ks\\_int = p11 + p22
-
+        
+        ks\\_int = p11 + p22
+        
         The integration is performed outside this method.
-
         """
 
         # Set up scattering geometry for 1-2 frame
@@ -206,9 +205,15 @@ class SCEBase(IsotropicScatteringMixin, GenericFTPhaseMixin):
         return ks_int.real
 
     def phase(self, mu_s, mu_i, dphi, npol=2):
-        """ IBA Phase function (not decomposed).
+        """
+        IBA Phase function (not decomposed).
 
-"""
+        Args:
+            mu_s: 
+            mu_i: 
+            dphi: 
+            npol:  (Default value = 2)
+        """
 
         if not hasattr(self, "_phase_norm"):
             self._phase_norm = self.compute_phase_norm()
@@ -228,15 +233,16 @@ class SCEBase(IsotropicScatteringMixin, GenericFTPhaseMixin):
         return smrt_matrix(self._phase_norm * ft_corr_fn * p)
 
     def compute_ka(self):
-        """ SCE absorption coefficient calculated from the low-loss assumption of a general lossy medium.
-
+        """
+        SCE absorption coefficient calculated from the low-loss assumption of a general lossy medium.
+        
         Calculates ka from wavenumber in free space (determined from sensor), and effective permittivity
         of the medium.
-
+        
         :return ka: absorption coefficient [m :sup:`-1`]
-
+        
         .. note::
-
+        
             This may not be suitable for high density material
 
         """

--- a/smrt/emmodel/sce_rechtsman08.py
+++ b/smrt/emmodel/sce_rechtsman08.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 
-"""Compute scattering with the Strong-Contrast Expansion (SCE) from Rechtsman and Torquato, 2008 adapted by Ghislain Picard (unpublished at time of writting).
-This SCE is the local version valid for quasi-static frequency (i.e. low frequency or small scatterers). A non-local version has been devised
-recently 
-
+"""Compute scattering with the Strong-Contrast Expansion (SCE) from Rechtsman and Torquato, 2008 adapted by Ghislain Picard (unpublished at time of writing).
+This SCE is the local version valid for quasi-static frequency (i.e. low frequency or small scatterers). A non-local version has been devised recently.
 """
 
 # Stdlib import
@@ -26,7 +24,7 @@ from .sce_common import SCEBase
 class SCER08(SCEBase):
 
     """
-        To be documented
+    To be documented.
     """
 
     def __init__(self, sensor, layer):
@@ -81,8 +79,8 @@ class SCER08(SCEBase):
         """ Calculation of complex effective permittivity of the medium,
         which is given by Maxwell Garnet in the case of Rechtsman and Torquato, 2008
 
-        :returns: effective_permittivity: complex effective permittivity of the medium
-
+        Returns:
+            float: Effective permittivity.
         """
 
         return maxwell_garnett_for_spheres(self.frac_volume, self.e0, self.eps)

--- a/smrt/emmodel/sce_torquato21.py
+++ b/smrt/emmodel/sce_torquato21.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-"""Compute scattering with the the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
-This SCE is the "non-local approximation" in Torquato also called "long range" in Tsang's books
+"""Compute scattering with the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021.
+This SCE is the "non-local approximation" in Torquato, also called "long range" in Tsang's books.
 It applies to scatterer size up to 1 wavelength.
 """
 
@@ -22,11 +22,13 @@ from .sce_common import SCEBase
 
 
 def derived_SCETK21(effective_permittivity_model):
-    """return a new SCE_ShortRange model with variant from the default SCE_ShortRange.
+    """Return a new SCE_ShortRange model with variant from the default SCE_ShortRange.
 
-    :param effective_permittivity_model: permittivity mixing formula.
+    Args:
+        effective_permittivity_model: Permittivity mixing formula.
 
-    :returns a new class inheriting from SCE_ShortRange but with patched methods
+    Returns:
+        class: A new class inheriting from SCE_ShortRange but with patched methods.
     """
 
     return derived_EMModel(SCETK21, effective_permittivity_model)
@@ -35,7 +37,7 @@ def derived_SCETK21(effective_permittivity_model):
 class SCETK21(AdjustableEffectivePermittivityMixins, SCEBase):
 
     """
-        To be documented
+    To be documented.
     """
 
     # default effective_permittivity_model is maxwell_garnett according to the SCE theory

--- a/smrt/emmodel/sce_torquato21_shortrange.py
+++ b/smrt/emmodel/sce_torquato21_shortrange.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-"""Compute scattering with the the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
-This SCE is the quasi-static version, called "local approximation" in Torquato and "short range" in Tsang's books
+"""Compute scattering with the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021.
+This SCE is the quasi-static version, called "local approximation" in Torquato and "short range" in Tsang's books.
 It applies to low frequency or small scatterers.
 Because of this assumption, local and non-local are undistinguishable, so that Rechtmans and Torquato, 2008 
 also provides a good reference for this implementation.
@@ -24,11 +24,13 @@ from .sce_common import SCEBase
 
 
 def derived_SCETK21_ShortRange(effective_permittivity_model):
-    """return a new SCE_ShortRange model with variant from the default SCE_ShortRange.
+    """Return a new SCE_ShortRange model with variant from the default SCE_ShortRange.
 
-    :param effective_permittivity_model: permittivity mixing formula.
+    Args:
+        effective_permittivity_model: Permittivity mixing formula.
 
-    :returns a new class inheriting from SCE_ShortRange but with patched methods
+    Returns:
+        class: A new class inheriting from SCE_ShortRange but with patched methods.
     """
 
     return derived_EMModel(SCETK21_ShortRange, effective_permittivity_model)
@@ -37,7 +39,7 @@ def derived_SCETK21_ShortRange(effective_permittivity_model):
 class SCETK21_ShortRange(AdjustableEffectivePermittivityMixins, SCEBase):
 
     """
-        To be documented
+    To be documented.
     """
 
     # default effective_permittivity_model is maxwell_garnett according to the SCE theory

--- a/smrt/emmodel/symsce_torquato21.py
+++ b/smrt/emmodel/symsce_torquato21.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-"""Compute scattering with the symmetrized  version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
+"""Compute scattering with the symmetrized version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
 under the non-local approximation, a.k.a long range in Tsang's books. The truncation of the series is at second order.
 """
 
@@ -22,11 +22,13 @@ from .sce_common import SCEBase
 
 
 def derived_SymSCETK21(effective_permittivity_model):
-    """return a new SymSCE model with variant from the default SymSCE.
+    """Return a new SymSCE model with variant from the default SymSCE.
 
-    :param effective_permittivity_model: permittivity mixing formula.
+    Args:
+        effective_permittivity_model: Permittivity mixing formula.
 
-    :returns: a new class inheriting from SymSCE but with patched methods
+    Returns:
+        class: A new class inheriting from SymSCE but with patched methods.
     """
 
     return derived_EMModel(SymSCETK21, effective_permittivity_model)

--- a/smrt/emmodel/symsce_torquato21.py
+++ b/smrt/emmodel/symsce_torquato21.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-
-"""Compute scattering with the symmetrized version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
+"""
+Computes scattering with the symmetrized version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
 under the non-local approximation, a.k.a long range in Tsang's books. The truncation of the series is at second order.
 """
 
@@ -22,7 +22,8 @@ from .sce_common import SCEBase
 
 
 def derived_SymSCETK21(effective_permittivity_model):
-    """Return a new SymSCE model with variant from the default SymSCE.
+    """
+    Returns a new SymSCE model with variant from the default SymSCE.
 
     Args:
         effective_permittivity_model: Permittivity mixing formula.

--- a/smrt/emmodel/symsce_torquato21_shortrange.py
+++ b/smrt/emmodel/symsce_torquato21_shortrange.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-"""Compute scattering with the symmetrized  version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021 
-This SCE is the quasi-static version, called "local approximation" in Torquato and "short range" in Tsang's books
+"""Compute scattering with the symmetrized version of the Strong-Contrast Expansion (SCE) from Torquato and Kom 2021.
+This SCE is the quasi-static version, called "local approximation" in Torquato and "short range" in Tsang's books.
 It applies to low frequency or small scatterers.
 Because of this assumption, local and non-local are undistinguishable, so that Rechtmans and Torquato, 2008 
 also provides a good reference for this implementation. The only difference is in fact the symmetrization.
@@ -24,11 +24,13 @@ from .sce_common import SCEBase
 
 
 def derived_SymSCETK21_ShortRange(effective_permittivity_model):
-    """return a new SymSCE_ShortRange model with variant from the default SymSCE_ShortRange.
+    """Return a new SymSCE_ShortRange model with variant from the default SymSCE_ShortRange.
 
-    :param effective_permittivity_model: permittivity mixing formula.
+    Args:
+        effective_permittivity_model: Permittivity mixing formula.
 
-    :returns a new class inheriting from SymSCE_ShortRange but with patched methods
+    Returns:
+        class: A new class inheriting from SymSCE_ShortRange but with patched methods.
     """
 
     return derived_EMModel(SymSCETK21_ShortRange, effective_permittivity_model)
@@ -37,7 +39,7 @@ def derived_SymSCETK21_ShortRange(effective_permittivity_model):
 class SymSCETK21_ShortRange(AdjustableEffectivePermittivityMixins, SCEBase):
 
     """
-        To be documented
+    To be documented.
     """
 
     # default effective_permittivity_model is polder_van_santen according to the SymSCE theory

--- a/smrt/inputs/__init__.py
+++ b/smrt/inputs/__init__.py
@@ -1,9 +1,8 @@
-
-
 """
 This package includes modules to create the medium and sensor configuration required for the simulations.
 The recommended way to build these objects::
 
+Example:
     from smrt import make_snowpack, sensor_list
 
     sp = make_snowpack([1000], density=[300], microstructure_model='sticky_hard_spheres', radius=[0.3e-3], stickiness=0.2)

--- a/smrt/inputs/__init__.py
+++ b/smrt/inputs/__init__.py
@@ -3,6 +3,7 @@ This package includes modules to create the medium and sensor configuration requ
 The recommended way to build these objects:
 
 Example::
+
     from smrt import make_snowpack, sensor_list
 
     sp = make_snowpack([1000], density=[300], microstructure_model='sticky_hard_spheres', radius=[0.3e-3], stickiness=0.2)

--- a/smrt/inputs/__init__.py
+++ b/smrt/inputs/__init__.py
@@ -1,8 +1,6 @@
 """
 This package includes modules to create the medium and sensor configuration required for the simulations.
-The recommended way to build these objects:
-
-Example::
+The recommended way to build these objects::
 
     from smrt import make_snowpack, sensor_list
 
@@ -22,5 +20,4 @@ in the package :py:mod:`smrt.inputs`. They could be imported using the full path
 
 Extension of the modules in the `inputs` package is welcome. This is as simple as adding new functions in the modules (e.g. in :py:mod:`~smrt.inputs.sensor_list`) or
 adding a new modules (e.g. `my_make_medium.py`) in this package and use the full path import.
-
 """

--- a/smrt/inputs/__init__.py
+++ b/smrt/inputs/__init__.py
@@ -1,8 +1,8 @@
 """
 This package includes modules to create the medium and sensor configuration required for the simulations.
-The recommended way to build these objects::
+The recommended way to build these objects:
 
-Example:
+Example::
     from smrt import make_snowpack, sensor_list
 
     sp = make_snowpack([1000], density=[300], microstructure_model='sticky_hard_spheres', radius=[0.3e-3], stickiness=0.2)

--- a/smrt/inputs/altimeter_list.py
+++ b/smrt/inputs/altimeter_list.py
@@ -10,11 +10,12 @@ from smrt.core.error import SMRTError
 
 
 def envisat_ra2(channel=None):
-    """return an Altimeter instance for the ENVISAT RA2 altimeter.
+    """
+    Returns an Altimeter instance for the ENVISAT RA2 altimeter.
 
-    :param channel: can be 'S', 'Ku', or both. Default is both.
-
-"""
+    Args:
+      channel: can be 'S', 'Ku', or both. Default is both.
+    """
 
     config = {
         'Ku': dict(frequency=13.575e9,

--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -164,6 +164,7 @@ def make_snowpack(thickness,
             The microstructure parameter(s) depend on the microstructure_model used and is documented in each microstructure_model module.
 
     Example::
+
         sp = make_snowpack([1, 10], "exponential", density=[200,300], temperature=[240, 250], corr_length=[0.2e-3, 0.3e-3])
     """
     sp = Snowpack(substrate=substrate, atmosphere=atmosphere)
@@ -834,6 +835,7 @@ def make_generic_stack(thickness, temperature=FREEZING_POINT, ks=0, ka=0, effect
         Snowpack: The constructed multi-layered medium.
 
     Example::
+
         sp = make_snowpack([1, 10], "exponential", density=[200,300], temperature=[240, 250], corr_length=[0.2e-3, 0.3e-3])
     """
 # TODO: Add an example
@@ -901,6 +903,7 @@ def add_transparent_layer(snowpack):
         snowpack: The substrate under the transparent layer.
 
     Example::
+
         sp = add_transparent_layer(sp)
     """
 
@@ -924,6 +927,7 @@ def make_transparent_volume(substrate=None,
         substrate: The substrate under the transparent layer.
 
     Example::
+    
         sp = make_transparent_volume()
     """
 

--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -23,9 +23,9 @@ Note:
     and according to the wave theory such sub-wavelength layers and their interface should have reduced or close to zero impact.
     It is the responsibility of the user to ensure that such thin layers (less than a quarter of wavelength) are removed from
     the snowpack. Alternatively, setting the `process_coherent_layers` option when using the
-    `smrt.rtsolver.dort` solver allows to deal with sub-wavelength layers provided they are isolated between two thick layers.
+    :py:mod:`smrt.rtsolver.dort` solver allows to deal with sub-wavelength layers provided they are isolated between two thick layers.
 
-    Note that `make_snowpack` is directly imported from `smrt` instead of `smrt.inputs.make_medium`. This feature is for convenience.
+    Note that `make_snowpack` is directly imported from :py:mod:`smrt` instead of :py:mod:`smrt.inputs.make_medium`. This feature is for convenience.
 """
 
 import itertools
@@ -505,7 +505,7 @@ def make_ice_layer(ice_type,
         brine_inclusion_shape: (firstyear and multiyear) Assumption for shape of brine inclusions (so far,
             "spheres" and "random_needles" (i.e. elongated ellipsoidal inclusions), and "mix_spheres_needles" are implemented)
         brine_volume_fraction: Brine / liquid water fraction in sea ice. Can be a value or a function depending on temperature and salinity.
-            See the module `smrt.permittivity.brine` for available options.
+            See the module :py:mod:`smrt.permittivity.brine` for available options.
             This parameter is optional, if not given brine volume fraction is calculated from temperature and salinity in
             `brine_volume_cox83_lepparanta88`.
         brine_permittivity_model: (firstyear and multiyear) Brine permittivity formulation

--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -6,7 +6,7 @@ for most usages. Extension of these functions is welcome on the condition they k
 
 The function `make_snowpack` is the first entry point the user should consider to build a snowpack.
 
-Example:
+Example::
     from smrt import make_snowpack
 
     sp = make_snowpack([1000], density=[300], microstructure_model='sticky_hard_spheres', radius=[0.3e-3], stickiness=0.2)
@@ -162,7 +162,7 @@ def make_snowpack(thickness,
             Thus, the documentation of this function is the reference. It describes precisely the available parameters.
             The microstructure parameter(s) depend on the microstructure_model used and is documented in each microstructure_model module.
 
-    Example:
+    Example::
         sp = make_snowpack([1, 10], "exponential", density=[200,300], temperature=[240, 250], corr_length=[0.2e-3, 0.3e-3])
     """
     sp = Snowpack(substrate=substrate, atmosphere=atmosphere)
@@ -832,7 +832,7 @@ def make_generic_stack(thickness, temperature=FREEZING_POINT, ks=0, ka=0, effect
     Returns:
         Snowpack: The constructed multi-layered medium.
 
-    Example:
+    Example::
         sp = make_snowpack([1, 10], "exponential", density=[200,300], temperature=[240, 250], corr_length=[0.2e-3, 0.3e-3])
     """
 # TODO: Add an example
@@ -899,7 +899,7 @@ def add_transparent_layer(snowpack):
     Args:
         snowpack: The substrate under the transparent layer.
 
-    Example:
+    Example::
         sp = add_transparent_layer(sp)
     """
 
@@ -922,7 +922,7 @@ def make_transparent_volume(substrate=None,
     Args:
         substrate: The substrate under the transparent layer.
 
-    Example:
+    Example::
         sp = make_transparent_volume()
     """
 

--- a/smrt/inputs/make_medium.py
+++ b/smrt/inputs/make_medium.py
@@ -7,6 +7,7 @@ for most usages. Extension of these functions is welcome on the condition they k
 The function `make_snowpack` is the first entry point the user should consider to build a snowpack.
 
 Example::
+
     from smrt import make_snowpack
 
     sp = make_snowpack([1000], density=[300], microstructure_model='sticky_hard_spheres', radius=[0.3e-3], stickiness=0.2)

--- a/smrt/inputs/make_soil.py
+++ b/smrt/inputs/make_soil.py
@@ -5,7 +5,7 @@
 To create a substrate, use or implement a helper function such as `make_soil`. This function is able to 
 automatically load a specific soil model and provides some soil permittivity formulae as well.
 
-Example:
+Example::
     from smrt import make_soil
     soil = make_soil("soil_wegmuller", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100, roughness_rms=1e-2)
 
@@ -46,7 +46,7 @@ def make_soil(substrate_model, permittivity_model, temperature, moisture=None,
     Returns:
         Instance of the soil substrate model.
 
-    Example:
+    Example::
         bottom = substrate.make('Flat', permittivity_model=complex('6-0.5j'))
         bottom = substrate.make('Wegmuller', permittivity_model='soil', roughness_rms=0.25, moisture=0.25)
     """

--- a/smrt/inputs/make_soil.py
+++ b/smrt/inputs/make_soil.py
@@ -1,18 +1,16 @@
 # coding: utf-8
 
-"""This module provides a function to build soil model and provides some soil permittivity formulae.
+"""Provides a function to build soil model and some soil permittivity formulae.
 
-To create a substrate, use/implement an helper function such as :py:func:`~smrt.substrate.substrate.make_soil`. This function is able to 
+To create a substrate, use or implement a helper function such as `make_soil`. This function is able to 
 automatically load a specific soil model and provides some soil permittivity formulae as well.
 
-Examples::
-
+Example:
     from smrt import make_soil
     soil = make_soil("soil_wegmuller", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100, roughness_rms=1e-2)
 
-It is recommand to first read the documentation of :py:func:`~smrt.substrate.substrate.make_soil` and then explore the different types of soil
+It is recommended to first read the documentation of `make_soil` and then explore the different types of soil
 models.
-
 """
 
 from functools import partial
@@ -30,23 +28,27 @@ from smrt.core.globalconstants import PERMITTIVITY_OF_FREE_SPACE
 
 def make_soil(substrate_model, permittivity_model, temperature, moisture=None,
               sand=None, clay=None, drymatter=None, **kwargs):
-    """ Construct a soil instance based on a given surface electromagnetic model, a permittivity model and parameters 
+    """
+    Constructs a soil instance based on a given surface electromagnetic model, a permittivity model and parameters.
 
-    :param substrate_model: name of substrate model, can be a class or a string. e.g. fresnel, wegmuller...
-    :param permittivity_model: permittivity_model to use. Can be a name ("hut_epss", "dobson85", "montpetit2008"), a function of
-        frequency and temperature or a complex value.
-    :param moisture: soil moisture in m:sup:`3` m:sup:`-3` to compute the permittivity. This parameter is used depending on the permittivity_model.
-    :param sand: soil relative sand content. This parameter is used or not depending on the permittivity_model.
-    :param clay: soil relative clay content. This parameter is used or not depending on the permittivity_model.
-    :param drymatter: soil content in dry matter in kg m:sup:`-3`. This parameter is used or not depending on the permittivity_model.
+    Args:
+        substrate_model: Name of substrate model, can be a class or a string. e.g. fresnel, wegmuller...
+        permittivity_model: Permittivity model to use. Can be a name ("hut_epss", "dobson85", "montpetit2008"), a function of
+            frequency and temperature or a complex value.
+        temperature: Temperature of the soil.
+        moisture: Soil moisture in m^3 m^-3 to compute the permittivity. This parameter is used depending on the permittivity_model.
+        sand: Soil relative sand content. This parameter is used or not depending on the permittivity_model.
+        clay: Soil relative clay content. This parameter is used or not depending on the permittivity_model.
+        drymatter: Soil content in dry matter in kg m^-3. This parameter is used or not depending on the permittivity_model.
+        **kwargs: Geometrical parameters depending on the substrate_model. Refer to the document of each model to see the
+            list of required and optional parameters. Usually, it is roughness_rms, corr_length, ...
 
-    :param \\**kwargs: geometrical parameters depending on the substrate_model. Refer to the document of each model to see the
-        list of required and optional parameters. Usually, it is roughness_rms, corr_length, ...
+    Returns:
+        Instance of the soil substrate model.
 
-    **Usage example:**::
-        TOTEST: bottom = substrate.make('Flat', permittivity_model=complex('6-0.5j'))
-        TOTEST:  bottom = substrate.make('Wegmuller', permittivity_model='soil', roughness_rms=0.25, moisture=0.25)
-
+    Example:
+        bottom = substrate.make('Flat', permittivity_model=complex('6-0.5j'))
+        bottom = substrate.make('Wegmuller', permittivity_model='soil', roughness_rms=0.25, moisture=0.25)
     """
 
     # process the permittivity_model argument
@@ -155,14 +157,23 @@ def soil_dielectric_constant_hut(frequency, tempK, SM, sand, clay, dm_rho):
 
 
 def soil_dielectric_constant_monpetit2008(frequency, temperature):
-    """Soil dielectric constant formulation based on the formulation Montpetit et al. 2018. 
-    The formulation is only valid for below-frrezing point temperature.
+    """
+    Computes the soil dielectric constant using the Montpetit et al. (2018) formulation.
 
-    Reference: Montpetit, B., Royer, A., Roy, A., & Langlois, A. (2018). In-situ passive microwave emission model 
-    parameterization of sub-arctic frozen organic soils. Remote Sensing of Environment, 205, 112–118. 
-    https://doi.org/10.1016/j.rse.2017.10.033
+    The formulation is only valid for below-freezing point temperature.
 
-"""
+    Reference:
+        Montpetit, B., Royer, A., Roy, A., & Langlois, A. (2018). In-situ passive microwave emission model 
+        parameterization of sub-arctic frozen organic soils. Remote Sensing of Environment, 205, 112–118. 
+        https://doi.org/10.1016/j.rse.2017.10.033
+
+    Args:
+        frequency: Frequency in Hz.
+        temperature: Temperature in Kelvin.
+
+    Returns:
+        complex: Soil dielectric constant.
+    """
     # from functools import partial
     # from smrt.inputs.make_soil import soil_dielectric_constant_dobson
     if temperature > 273.15:

--- a/smrt/inputs/make_soil.py
+++ b/smrt/inputs/make_soil.py
@@ -6,6 +6,7 @@ To create a substrate, use or implement a helper function such as `make_soil`. T
 automatically load a specific soil model and provides some soil permittivity formulae as well.
 
 Example::
+
     from smrt import make_soil
     soil = make_soil("soil_wegmuller", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100, roughness_rms=1e-2)
 
@@ -47,6 +48,7 @@ def make_soil(substrate_model, permittivity_model, temperature, moisture=None,
         Instance of the soil substrate model.
 
     Example::
+
         bottom = substrate.make('Flat', permittivity_model=complex('6-0.5j'))
         bottom = substrate.make('Wegmuller', permittivity_model='soil', roughness_rms=0.25, moisture=0.25)
     """

--- a/smrt/inputs/make_soil.py
+++ b/smrt/inputs/make_soil.py
@@ -47,7 +47,7 @@ def make_soil(substrate_model, permittivity_model, temperature, moisture=None,
     Returns:
         Instance of the soil substrate model.
 
-    Example::
+    Example (TOTEST)::
 
         bottom = substrate.make('Flat', permittivity_model=complex('6-0.5j'))
         bottom = substrate.make('Wegmuller', permittivity_model='soil', roughness_rms=0.25, moisture=0.25)

--- a/smrt/inputs/sensor_list.py
+++ b/smrt/inputs/sensor_list.py
@@ -39,6 +39,7 @@ def amsre(channel=None, frequency=None, polarization=None, theta=55):
         Sensor: Instance of Sensor.
 
     Example::
+    
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only
@@ -76,6 +77,7 @@ def amsr2(channel=None, frequency=None, polarization=None, theta=55):
         Sensor: Instance of Sensor.
 
     Example::
+
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only

--- a/smrt/inputs/sensor_list.py
+++ b/smrt/inputs/sensor_list.py
@@ -38,7 +38,7 @@ def amsre(channel=None, frequency=None, polarization=None, theta=55):
     Returns:
         Sensor: Instance of Sensor.
 
-    Example:
+    Example::
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only
@@ -75,7 +75,7 @@ def amsr2(channel=None, frequency=None, polarization=None, theta=55):
     Returns:
         Sensor: Instance of Sensor.
 
-    Example:
+    Example::
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only

--- a/smrt/inputs/sensor_list.py
+++ b/smrt/inputs/sensor_list.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 """The sensor configuration includes all the information describing the sensor viewing geometry (incidence, ...)
-and operating parameters (frequency, polarization, ...). The easiest and recommended way to create a :py:class:`~smrt.core.Sensor` instance is
-to use one of the convenience functions listed below. The generic functions :py:func:`passive` and :py:func:`active` should cover all the usages,
+and operating parameters (frequency, polarization, ...). The easiest and recommended way to create a `Sensor` instance is
+to use one of the convenience functions listed below. The generic functions `passive` and `active` should cover all the usages,
 but functions for specific sensors are more convenient. See examples in the functions documentation below. We recommend to add new sensors/functions here and share your file to be included in SMRT.
 
 .. autofunction:: passive
@@ -20,26 +20,29 @@ from smrt.core.sensor import passive, active  # import so they are available fro
 
 
 def amsre(channel=None, frequency=None, polarization=None, theta=55):
-    """ Configuration for AMSR-E sensor.
+    """
+    Returns a configuration for AMSR-E sensor.
 
     This function can be used to simulate all 12 AMSR-E channels i.e. frequencies of 6.925, 10.65, 18.7, 23.8, 36.5 and 89 GHz
     at both polarizations H and V. Alternatively single channels can be specified with 3-character identifiers. 18 and 19 GHz can
-    be used interchangably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
-    Note that if you need both H and V polarization (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
+    be used interchangeably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
+    Note that if both H and V polarization are needed (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
     as this will result in a more efficient simulation, because most rtsolvers anyway compute both polarizations in one shot.
 
-    :param channel: single channel identifier
-    :type channel: 3-character string
+    Args:
+        channel: Single channel identifier (3-character string).
+        frequency: Frequency value.
+        polarization: Polarization.
+        theta: Incidence angle.
 
-    :returns: :py:class:`Sensor` instance
+    Returns:
+        Sensor: Instance of Sensor.
 
-    Example::
-
+    Example:
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only
         radiometer = sensor.amsre('06H')  # 6.925 GHz channel
-
     """
 
     amsre_frequency_dict = {
@@ -54,26 +57,29 @@ def amsre(channel=None, frequency=None, polarization=None, theta=55):
 
 
 def amsr2(channel=None, frequency=None, polarization=None, theta=55):
-    """ Configuration for AMSR-2 sensor.
+    """
+    Returns a configuration for AMSR-2 sensor.
 
     This function can be used to simulate all 14 AMSR2 channels i.e. frequencies of 6.925, 10.65, 18.7, 23.8, 36.5 and 89 GHz
     at both polarizations H and V. Alternatively single channels can be specified with 3-character identifiers. 18 and 19 GHz can
-    be used interchangably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
-    Note that if you need both H and V polarization (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
+    be used interchangeably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
+    Note that if both H and V polarization are needed (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
     as this will result in a more efficient simulation, because most rtsolvers anyway compute both polarizations in one shot.
 
-    :param channel: single channel identifier
-    :type channel: 3-character string
+    Args:
+        channel: Single channel identifier (3-character string).
+        frequency: Frequency value.
+        polarization: Polarization.
+        theta: Incidence angle.
 
-    :returns: :py:class:`Sensor` instance
+    Returns:
+        Sensor: Instance of Sensor.
 
-    Usage example::
-
+    Example:
         from smrt import sensor
         radiometer = sensor.amsre()  # Simulates all channels
         radiometer = sensor.amsre('36V')  # Simulates 36.5 GHz channel only
         radiometer = sensor.amsre('06H')  # 6.925 GHz channel
-
     """
 
     amsr2_frequency_dict = {
@@ -89,19 +95,24 @@ def amsr2(channel=None, frequency=None, polarization=None, theta=55):
 
 
 def cimr(channel=None, frequency=None, polarization=None, theta=55):
-    """ Configuration for AMSR-2 sensor.
+    """
+    Returns a configuration for CIMR sensor.
 
     This function can be used to simulate all 10 CIMR channels i.e. frequencies of 1.4, 6.9, 10.6, 18.7, 36.5 GHz
     at both polarizations H and V. Alternatively single channels can be specified with 3-character identifiers. 18 and 19 GHz can
-    be used interchangably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
-    Note that if you need both H and V polarization (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
+    be used interchangeably to represent 18.7 GHz, similarly either 36 and 37 can be used to represent the 36.5 GHz channel.
+    Note that if both H and V polarization are needed (at 37 GHz for instance), use channel="37" instead of channel=["37V", "37H"]
     as this will result in a more efficient simulation, because most rtsolvers anyway compute both polarizations in one shot.
 
-    :param channel: single channel identifier
-    :type channel: 3-character string
+    Args:
+        channel: Single channel identifier (3-character string).
+        frequency: Frequency value.
+        polarization: Polarization.
+        theta: Incidence angle.
 
-    :returns: :py:class:`Sensor` instance
-"""
+    Returns:
+        Sensor: Instance of Sensor.
+    """
 
     cimr_frequency_dict = {
         '01': 1.4135e9,
@@ -159,16 +170,19 @@ def common_conical_pmw(sensor_name, frequency_dict, channel=None, frequency=None
 
 
 def quikscat(channel=None, theta=None):
-    """ Configuration for quikscat sensor.
+    """
+    Returns a configuration for quikscat sensor.
 
-     This function can be used to simulate the 4 QUIKSCAT channels i.e. incidence angles 46° and 54° and HH and VV polarizations.
-     Alternatively a subset of these channels can be specified with 4-character identifiers with polarization first .e.g. HH46, VV54
+    This function can be used to simulate the 4 QUIKSCAT channels i.e. incidence angles 46° and 54° and HH and VV polarizations.
+    Alternatively a subset of these channels can be specified with 4-character identifiers with polarization first .e.g. HH46, VV54
 
-     :param channel: single channel identifier
-     :type channel: 4-character string
+    Args:
+        channel: Single channel identifier (4-character string).
+        theta: Incidence angle.
 
-     :returns: :py:class:`Sensor` instance
-"""
+    Returns:
+        Sensor: Instance of Sensor.
+    """
 
     channel_map = {'HH46': dict(polarization='H', polarization_inc='H', theta=46, theta_inc=46),
                    'VV54': dict(polarization='V', polarization_inc='V', theta=54, theta_inc=54)
@@ -199,17 +213,20 @@ def quikscat(channel=None, theta=None):
 
 
 def ascat(theta=None):
-    """ Configuration for ASCAT on MetOp satellites.
+    """
+    Returns a configuration for ASCAT on MetOp satellites.
 
-        Characteristics of the observation configuration: https://ieeexplore.ieee.org/document/7815274
+    Characteristics of the observation configuration: https://ieeexplore.ieee.org/document/7815274
 
-       This function returns a sensor at 5.255 GHz (C-band) and VV polarization. The incidence angle can be chosen or is by defaut from 25° to 65° every 5°
+    This function returns a sensor at 5.255 GHz (C-band) and VV polarization. The incidence angle can be chosen or is by default from 25° to 65° every 5°
 
-       :param theta: incidence angle (between 25 and 65° in principle)
-       :type theta: float or sequence
+    Args:
+        theta: Incidence angle (between 25 and 65° in principle).
 
-       :returns: :py:class:`Sensor` instance
-  """
+    Returns:
+        Sensor: Instance of Sensor.
+    """
+
     if theta is None:
         theta = np.arange(25, 70, 5)
 
@@ -221,15 +238,18 @@ def ascat(theta=None):
 
 
 def sentinel1(theta=None):
-    """ Configuration for C-SAR on Sentinel 1.
+    """
+    Returns a configuration for C-SAR on Sentinel 1.
 
-       This function return a sensor at 5.405 GHz (C-band). The incidence angle can be chosen or is by defaut from 20 to 45° by step of 5°
+    This function returns a sensor at 5.405 GHz (C-band). The incidence angle can be chosen or is by default from 20 to 45° by step of 5°
 
-       :param theta: incidence angle
-       :type theta: float or sequence
+    Args:
+        theta: Incidence angle.
 
-       :returns: :py:class:`Sensor` instance
-  """
+    Returns:
+        Sensor: Instance of Sensor.
+    """
+
     if theta is None:
         theta = np.arange(20, 46, 5)
 
@@ -239,15 +259,18 @@ def sentinel1(theta=None):
 
 
 def smos(theta=None):
-    """ Configuration for MIRAS on SMOS.
+    """
+    Returns a configuration for MIRAS on SMOS.
 
-       This function returns a passive sensor at 1.41 GHz (L-band). The incidence angle can be chosen or is by defaut from 0 to 60° by step of 5°
+    This function returns a passive sensor at 1.41 GHz (L-band). The incidence angle can be chosen or is by default from 0 to 60° by step of 5°
 
-       :param theta: incidence angle
-       :type theta: float or sequence
+    Args:
+        theta: Incidence angle.
 
-       :returns: :py:class:`Sensor` instance
-  """
+    Returns:
+        Sensor: Instance of Sensor.
+    """
+
     if theta is None:
         theta = np.arange(0, 61, 5)
 
@@ -259,10 +282,20 @@ def smos(theta=None):
 
 
 def smap(mode, theta=40):
-    """Configuration for the passive (mode=P) and active (mode=A) sensor on smap
+    """
+    Returns a configuration for the passive (mode='P') and active (mode='A') sensor on SMAP.
 
-        This function returns either a passive sensor at 1.4 GHz (L-band) sensor or an active sensor at 1.26 GHz. The incidence angle is 40°.
+    This function returns either a passive sensor at 1.4 GHz (L-band) sensor or an active sensor at 1.26 GHz. The incidence angle is 40°.
 
+    Args:
+        mode: 'P' for passive, 'A' for active.
+        theta: Incidence angle.
+
+    Returns:
+        Sensor: Instance of Sensor.
+
+    Raises:
+        SMRTError: If mode is not 'A' or 'P'.
     """
 
     if mode == 'P':

--- a/smrt/interface/__init__.py
+++ b/smrt/interface/__init__.py
@@ -1,7 +1,7 @@
 """Contains different types of boundary conditions between the layers.
 
-For developers:
+..admonition::  **For developers**
     All the different types of interface must define the methods:
-    - specular_reflection_matrix
-    - coherent_transmission_matrix
+    - 'specular_reflection_matrix'
+    - 'coherent_transmission_matrix'
 """

--- a/smrt/interface/__init__.py
+++ b/smrt/interface/__init__.py
@@ -1,7 +1,7 @@
-""" This module contains different types of boundary conditions between the layers.
+"""Contains different types of boundary conditions between the layers.
 
-.. admonition::  **For developers**
-
-    All the different types of interface must define the methods: `specular_reflection_matrix` and `coherent_transmission_matrix`.
-
+For developers:
+    All the different types of interface must define the methods:
+    - specular_reflection_matrix
+    - coherent_transmission_matrix
 """

--- a/smrt/interface/coherent_flat.py
+++ b/smrt/interface/coherent_flat.py
@@ -1,7 +1,5 @@
-
-
 """
-Implement the coherent flat pseudo-interface, as in MEMLS. This interface is obtained by collapsing one layer and two interfaces into a single interface. Scattering in the layer is neglected.
+Implements the coherent flat pseudo-interface, as in MEMLS. This interface is obtained by collapsing one layer and two interfaces into a single interface. Scattering in the layer is neglected.
 
 
 """
@@ -46,9 +44,10 @@ def process_coherent_layers(snowpack, emmodel_list, sensor):
 
 
 class CoherentFlat(object):
-    """A flat surface. The reflection is in the specular direction and the coefficient is calculated with the Fresnel coefficients
+    """
+    Represents a flat surface. The reflection is in the specular direction and the coefficient is calculated with the Fresnel coefficients.
 
-"""
+    """
     args = []
     optional_args = {}
 
@@ -61,16 +60,19 @@ class CoherentFlat(object):
         self.permittivity = permittivity
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the reflection coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium.
-        :param mu1: array of cosine of incident angles.
-        :param npol: number of polarization.
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
-"""
+        Returns:
+            The reflection matrix.
+        """
 
         R01_v, R01_h, R1t_v, R1t_h, exp_kd, exp_2kd, mu_t = self._prepare_computation(frequency, eps_1, eps_2, mu1)
 
@@ -91,17 +93,19 @@ class CoherentFlat(object):
         return smrt_matrix(0)
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for the azimuthal mode m
-           and for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for the azimuthal mode m and for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium.
-        :param mu1: array of cosine of incident angles.
-        :param npol: number of polarization.
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
-"""
+        Returns:
+            The transmission matrix.
+        """
 
         R01_v, R01_h, R1t_v, R1t_h, exp_kd, exp_2kd, mu_t = self._prepare_computation(frequency, eps_1, eps_2, mu1)
 

--- a/smrt/interface/flat.py
+++ b/smrt/interface/flat.py
@@ -1,8 +1,5 @@
-
-
 """
-Implement the flat interface boundary condition between layers charcterized by their effective permittivities. The reflection and transmission
-are computed using the Fresnel coefficient.
+Implements the flat interface boundary condition between layers characterized by their effective permittivities. The reflection and transmission are computed using the Fresnel coefficient.
 
 """
 
@@ -12,23 +9,27 @@ from smrt.core.interface import Interface
 
 
 class Flat(Interface):
-    """A flat surface. The reflection is in the specular direction and the coefficient is calculated with the Fresnel coefficients
+    """
+    Represents a flat surface. The reflection is in the specular direction and the coefficient is calculated with the Fresnel coefficients.
 
-"""
+    """
     args = []
     optional_args = {}
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the reflection coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium.
-        :param mu1: array of cosine of incident angles.
-        :param npol: number of polarization.
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
-"""
+        Returns:
+            The reflection matrix.
+        """
 
         return fresnel_reflection_matrix(eps_1, eps_2, mu1, npol)
 
@@ -36,16 +37,19 @@ class Flat(Interface):
         return smrt_matrix(0)
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium.
-        :param mu1: array of cosine of incident angles.
-        :param npol: number of polarization.
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
-"""
+        Returns:
+            The transmission matrix.
+        """
 
         return fresnel_transmission_matrix(eps_1, eps_2, mu1, npol)
 

--- a/smrt/interface/geometrical_optics.py
+++ b/smrt/interface/geometrical_optics.py
@@ -1,21 +1,13 @@
 """
-Implement the interface boundary condition under the Geometrical Approximation between layers charcterized by their effective permittivities.
-This approximation is suitable for surface with roughness much larger than the roughness scales, typically k*s >> 1 and k*l >> 1, where s the rms heigth and l
-the correlation length. The precise validity range must be investigated by the user, this code does not raise any warning. An important charcateristic of
-this approximation is that the scattering do not directly depend on frequency, the only (probably weak) dependence is through the permittivities of the media.
+Implements the interface boundary condition under the Geometrical Approximation between layers characterized by their effective permittivities. This approximation is suitable for surfaces with roughness much larger than the roughness scales, typically k*s >> 1 and k*l >> 1, where s is the rms height and l is the correlation length. The precise validity range must be investigated by the user, this code does not raise any warning. An important characteristic of this approximation is that the scattering does not directly depend on frequency, the only (probably weak) dependence is through the permittivities of the media.
 
 The model is parameterized by the mean_square_slope which can be calculated as mean_square_slope = 2*s**2/l**2 for surface with a Gaussian autocorrelation function.
 Other equations may exist for other autocorrelation function.
 
-This implementation is largely based on Tsang and Kong, Scattering of Electromagnetic Waves: Advanced Topics, 2001 (Tsang_tomeIII in the following)
+This implementation is largely based on Tsang and Kong, Scattering of Electromagnetic Waves: Advanced Topics, 2001 (Tsang_tomeIII in the following).
 
-
-.. note::
-    This implementation set coherent reflection and transmission to zero, which is expected theoretically for a very rough surface.
-    However, first order radiative transfer solvers (such a nadir_lrm_altimetry) do not work well in this case because
-    the transmission through the layers is neglected. In such case, it is recommended to use
-    :py:mod:`smrt.interface.geometrical_optics_backscatter` which provides an approximation that set the coherent
-    transmission based on energy conservation assuming all the transmitted energy is in the refracted direction.
+Note:
+    This implementation sets coherent reflection and transmission to zero, which is expected theoretically for a very rough surface. However, first order radiative transfer solvers (such as nadir_lrm_altimetry) do not work well in this case because the transmission through the layers is neglected. In such case, it is recommended to use smrt.interface.geometrical_optics_backscatter which provides an approximation that sets the coherent transmission based on energy conservation assuming all the transmitted energy is in the refracted direction.
 """
 
 import numpy as np
@@ -29,7 +21,10 @@ from smrt.core.interface import Interface
 
 
 class GeometricalOptics(Interface):
-    """A very rough surface."""
+    """
+    Represents a very rough surface.
+
+    """
 
     args = ["mean_square_slope"]
     optional_args = {"shadow_correction": True}
@@ -39,29 +34,37 @@ class GeometricalOptics(Interface):
         return np.clip(mu, 0.1, 1)
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the reflection coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
+        Returns:
+            The reflection matrix.
         """
 
         return smrt_matrix(0)
 
     def diffuse_reflection_matrix(self, frequency, eps_1, eps_2, mu_s, mu_i, dphi, npol):
-        """compute the reflection coefficients for an array of incident, scattered and azimuth angles
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incident, scattered and azimuth angles in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_s: Array of cosine of scattered angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
+        Returns:
+            The reflection matrix.
         """
         mu_i = np.atleast_1d(self.clip_mu(mu_i))[np.newaxis, np.newaxis, :]
         mu_s = np.atleast_1d(self.clip_mu(mu_s))[np.newaxis, :, np.newaxis]
@@ -160,31 +163,37 @@ class GeometricalOptics(Interface):
         return generic_ft_even_matrix(transmission_function, m_max, nsamples=256)
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for the azimuthal mode m
-           and for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for the azimuthal mode m and for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
+        Returns:
+            The transmission matrix.
         """
 
         return smrt_matrix(0)
 
     def diffuse_transmission_matrix(self, frequency, eps_1, eps_2, mu_t, mu_i, dphi, npol):
-        """compute the transmission coefficients for an array of incident, scattered and azimuth angles
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for an array of incident, scattered and azimuth angles in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu_i: array of cosine of incident angles
-        :param mu_t: array of cosine of transmitted wave angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_t: Array of cosine of transmitted wave angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
+        Returns:
+            The transmission matrix.
         """
         n_2 = np.sqrt(eps_2)
         n_1 = np.sqrt(eps_1)
@@ -279,8 +288,20 @@ class GeometricalOptics(Interface):
         return transmission_coefficients * coef.real
 
     def reflection_integrand_for_energy_conservation_test(self, frequency, eps_1, eps_2, mu_s, mu_i, dphi):
-        """function relevant to compute energy conservation. See p87 in Tsang_tomeIII.
-"""
+        """
+        Computes the function relevant to compute energy conservation. See p87 in Tsang_tomeIII.
+
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_s: Array of cosine of scattered angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+
+        Returns:
+            Tuple of coefficients for energy conservation.
+        """
         mu_i = np.atleast_1d(self.clip_mu(mu_i))[np.newaxis, np.newaxis, :]
         mu_s = np.atleast_1d(self.clip_mu(mu_s))[np.newaxis, :, np.newaxis]
         dphi = np.atleast_1d(dphi)[:, np.newaxis, np.newaxis]
@@ -317,8 +338,20 @@ class GeometricalOptics(Interface):
             coef * (vi_ks**2 * abs2(Rh) + hi_ks**2 * abs2(Rv))
 
     def transmission_integrand_for_energy_conservation_test(self, frequency, eps_1, eps_2, mu_t, mu_i, dphi):
-        """function relevant to compute energy conservation. See p87 in Tsang_tomeIII.
-"""
+        """
+        Computes the function relevant to compute energy conservation. See p87 in Tsang_tomeIII.
+
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_t: Array of cosine of transmitted wave angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+
+        Returns:
+            Tuple of coefficients for energy conservation.
+        """
         n_2 = np.sqrt(eps_2)
         n_1 = np.sqrt(eps_1)
 

--- a/smrt/interface/geometrical_optics_backscatter.py
+++ b/smrt/interface/geometrical_optics_backscatter.py
@@ -1,5 +1,3 @@
-
-
 """
 Implement the interface boundary condition under the Geometrical Approximation between layers characterized by their
 effective permittivities. This code is for backscatter only, that is, to use as a substrate and at low frequency when
@@ -7,10 +5,7 @@ the backscatter is the main mecahnism, and conversely when mulitple scattering a
 substrate are negligible. In other case, it is recommended to use
 :py:mod:`~smrt.interface.geometrical_optics`.
 
-The transmitted energy is also computed in an approximate way suitable for first order scattering such as
-:py:mod:``smrt.rtsolver.nadir_lrm_altimetry`. It uses energy conservation to compute the total transmitted energy and
-consider that all this energy is transmitted in the refracted direction. This approach compensate for the deficiencies of
-first order scattering RT solvers.
+The transmitted energy is also computed in an approximate way suitable for first order scattering such as smrt.rtsolver.nadir_lrm_altimetry. It uses energy conservation to compute the total transmitted energy and considers that all this energy is transmitted in the refracted direction. This approach compensates for the deficiencies of first order scattering RT solvers.
 
 """
 
@@ -23,38 +18,47 @@ from smrt.interface.geometrical_optics import shadow_function, GeometricalOptics
 
 
 class GeometricalOpticsBackscatter(Interface):
-    """A very rough surface.
+    """
+    Represents a very rough surface.
 
-"""
+    """
     args = ["mean_square_slope"]
     optional_args = {"shadow_correction": True}
 
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the reflection coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
+        Returns:
+            The reflection matrix.
 """
 
         return smrt_matrix(0)
 
 
     def diffuse_reflection_matrix(self, frequency, eps_1, eps_2, mu_s, mu_i, dphi, npol):
-        """compute the reflection coefficients for an array of incident, scattered and azimuth angles
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incident, scattered and azimuth angles in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_s: Array of cosine of scattered angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
+        Returns:
+            The reflection matrix.
 """
         mu_s = np.atleast_1d(mu_s)
         mu_i = np.atleast_1d(mu_i)
@@ -105,17 +109,18 @@ class GeometricalOpticsBackscatter(Interface):
         return diffuse_refl_coeff
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted. While Geometrical Optics, we here consider that power not reflected
-           is scattered in the specular transmitted direction. This is an approximation which is reasonable in the context of a "1st order"
-           geometrical optics.
+        """
+        Computes the transmission coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted. While Geometrical Optics, it here considers that power not reflected is scattered in the specular transmitted direction. This is an approximation which is reasonable in the context of a "1st order" geometrical optics.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
+        Returns:
+            The transmission matrix.
 """
         go = GeometricalOptics(mean_square_slope=self.mean_square_slope, shadow_function=self.shadow_correction)
         total_reflection = go.reflection_coefficients(frequency, eps_1, eps_2, mu1)

--- a/smrt/interface/iem_fung92.py
+++ b/smrt/interface/iem_fung92.py
@@ -1,5 +1,3 @@
-
-
 """
 Implement the interface boundary condition under IEM formulation provided by Fung et al. 1992. in IEEE TGRS.
 Use of this code requires special attention because of two issues:
@@ -16,17 +14,14 @@ situations, this code is not recommended.
 ks*kl < sqrt(eps) where k is the wavenumber, s the rms height and l the correlation length. The code print a warning
 when out of this range. There is also limitation for smooth surfaces but no warning is printed.
 
-   Example::
-
-        # rms height and corr_length values work at 10 GHz
-        substrate = make_soil("iem_fung92", "dobson85", temperature=260,
+Example:
+    # rms height and corr_length values work at 10 GHz
+    substrate = make_soil("iem_fung92", "dobson85", temperature=260,
                                             roughness_rms=1e-3,
                                             corr_length=5e-2,
                                             autocorrelation_function="exponential",
                                             moisture=moisture,
                                             clay=clay, sand=sand, drymatter=drymatter)
-
-
 """
 
 import numpy as np
@@ -40,26 +35,29 @@ from smrt.core.vector3 import vector3
 
 
 class IEM_Fung92(Interface):
-    """A moderate rough surface model with backscatter, specular reflection and transmission only. It is not suitable
-    for emissivity calculations.Use with care!
+    """
+    Represents a moderate rough surface model with backscatter, specular reflection and transmission only. It is not suitable for emissivity calculations. Use with care!
 
-"""
+    """
     args = ["roughness_rms", "corr_length"]
     optional_args = {"autocorrelation_function": "exponential",
                      "warning_handling": "print",
                      "series_truncation": 10}
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the reflection coefficients for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
-"""
+        Returns:
+            The reflection matrix.
+        """
         k2 = (2 * np.pi * frequency / C_SPEED) ** 2 * abs2(eps_1)
         # Eq: 2.1.94 in Tsang 2001 Tome I
         return fresnel_reflection_matrix(eps_1, eps_2, mu1, npol) * np.exp(-4 * k2 * self.roughness_rms**2 * mu1**2)
@@ -82,16 +80,21 @@ class IEM_Fung92(Interface):
 
 
     def diffuse_reflection_matrix(self, frequency, eps_1, eps_2, mu_s, mu_i, dphi, npol, debug=False):
-        """compute the reflection coefficients for an array of incident, scattered and azimuth angles
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the reflection coefficients for an array of incident, scattered and azimuth angles in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu_s: Array of cosine of scattered angles.
+            mu_i: Array of cosine of incident angles.
+            dphi: Azimuth angles.
+            npol: Number of polarization.
 
-        :return: the reflection matrix
-"""
+        Returns:
+            The reflection matrix.
+        """
         mu_s = np.atleast_1d(mu_s)
         mu_i = np.atleast_1d(mu_i)
 
@@ -198,17 +201,19 @@ class IEM_Fung92(Interface):
         return diffuse_refl_coeff
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for the azimuthal mode m
-           and for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for the azimuthal mode m and for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
-"""
+        Returns:
+            The transmission matrix.
+        """
         k0 = 2 * np.pi * frequency / C_SPEED
 
         k_iz = k0 * np.sqrt(eps_1).real * mu1

--- a/smrt/interface/iem_fung92.py
+++ b/smrt/interface/iem_fung92.py
@@ -14,7 +14,8 @@ situations, this code is not recommended.
 ks*kl < sqrt(eps) where k is the wavenumber, s the rms height and l the correlation length. The code print a warning
 when out of this range. There is also limitation for smooth surfaces but no warning is printed.
 
-Example:
+Example::
+
     # rms height and corr_length values work at 10 GHz
     substrate = make_soil("iem_fung92", "dobson85", temperature=260,
                                             roughness_rms=1e-3,

--- a/smrt/interface/iem_fung92_brogioni10.py
+++ b/smrt/interface/iem_fung92_brogioni10.py
@@ -1,10 +1,5 @@
-
-
 """
-Implement the interface boundary condition under IEM formulation provided by Fung et al. 1992. in IEEE TGRS 
-with an extended domain of validity (for large roughness or correlation length) by switching the Fresnel 
-coefficients according to Brogioni et al. 2010, IJRS (doi: 10.1080/01431160903232808). A better but more
-complex approach is given by Wu et al. 2003 (to be implemented).
+Implements the interface boundary condition under IEM formulation provided by Fung et al. 1992 in IEEE TGRS with an extended domain of validity (for large roughness or correlation length) by switching the Fresnel coefficients according to Brogioni et al. 2010, IJRS (doi: 10.1080/01431160903232808). A better but more complex approach is given by Wu et al. 2003 (to be implemented).
 
 Use of this code requires special attention.
 
@@ -18,9 +13,10 @@ from smrt.core.error import SMRTError
 
 
 class IEM_Fung92_Briogoni10(IEM_Fung92):
-    """A moderate rough surface model with backscatter, specular reflection and transmission only. Use with care!
+    """
+    Represents a moderate rough surface model with backscatter, specular reflection and transmission only. Use with care!
 
-"""
+    """
 
     def check_validity(self, ks, kl, eps_r):
 
@@ -32,6 +28,10 @@ class IEM_Fung92_Briogoni10(IEM_Fung92):
         """calculate the fresnel coefficients at the angle mu_i or 0° depending on ks*kl. The transition is abrupt."""
 
         if ks * kl > np.sqrt(eps_2 / eps_1):
+            Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, 1)
+        else:
+            Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, mu_i)
+        return Rv, Rh
             Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, 1)
         else:
             Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, mu_i)

--- a/smrt/interface/iem_fung92_brogioni10.py
+++ b/smrt/interface/iem_fung92_brogioni10.py
@@ -32,7 +32,3 @@ class IEM_Fung92_Briogoni10(IEM_Fung92):
         else:
             Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, mu_i)
         return Rv, Rh
-            Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, 1)
-        else:
-            Rv, Rh, _ = fresnel_coefficients(eps_1, eps_2, mu_i)
-        return Rv, Rh

--- a/smrt/interface/radar_calibration_sphere.py
+++ b/smrt/interface/radar_calibration_sphere.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-"""Surface with a backscatter of 4pi.
+"""
+Implements a surface with a backscatter of 4pi.
 
 """
 

--- a/smrt/interface/transparent.py
+++ b/smrt/interface/transparent.py
@@ -1,4 +1,4 @@
-"""A transparent interface (no reflection). Useful for the unit-test mainly.
+"""Implements a transparent interface (no reflection). Useful mainly for unit tests.
 
 """
 
@@ -11,17 +11,19 @@ class Transparent(object):
     optional_args = {}
 
     def specular_reflection_matrix(self, frequency, eps_1, eps_2, mu1, npol):
+        """
+        Computes the reflection coefficients for the azimuthal mode m and for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        """compute the reflection coefficients for the azimuthal mode m
-           and for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mhu1: array of cosine of incident angles
-        :param npol: number of polarization
-
-"""
+        Returns:
+            The reflection matrix.
+        """
         assert len(mu1.shape) == 1  # 1D array
 
         return smrt_matrix.zeros((npol, len(mu1)))
@@ -30,17 +32,19 @@ class Transparent(object):
         return smrt_matrix(0)
 
     def coherent_transmission_matrix(self, frequency, eps_1, eps_2, mu1, npol):
-        """compute the transmission coefficients for the azimuthal mode m
-           and for an array of incidence angles (given by their cosine)
-           in medium 1. Medium 2 is where the beam is transmitted.
+        """
+        Computes the transmission coefficients for the azimuthal mode m and for an array of incidence angles (given by their cosine) in medium 1. Medium 2 is where the beam is transmitted.
 
-        :param eps_1: permittivity of the medium where the incident beam is propagating.
-        :param eps_2: permittivity of the other medium
-        :param mu1: array of cosine of incident angles
-        :param npol: number of polarization
+        Args:
+            frequency: Frequency of the incident wave.
+            eps_1: Permittivity of the medium where the incident beam is propagating.
+            eps_2: Permittivity of the other medium.
+            mu1: Array of cosine of incident angles.
+            npol: Number of polarization.
 
-        :return: the transmission matrix
-"""
+        Returns:
+            The transmission matrix.
+        """
         return smrt_matrix.ones((npol, len_atleast_1d(mu1)))
 
     def diffuse_transmission_matrix(self, frequency, eps_1, eps_2, mu_s, mu_i, dphi, npol):

--- a/smrt/microstructure_model/__init__.py
+++ b/smrt/microstructure_model/__init__.py
@@ -1,13 +1,13 @@
 """
+Provides several microstructure models.
 
-This package provides several microstructure models. Because these representations are different, the parameters to
-describe actual snow micro-structure depends on the model. For instance, the Sticky Hard Spheres medium is implemented
-in :py:mod:`~smrt.microstructure_model.sticky_hard_spheres` and its parameters are: the `radius` (required) and
-the `stickiness` (optional, default value is non-sticky, even though we do recommend to use a stickiness of ~0.1-0.3 in practice).
+Because these representations are different, the parameters to describe actual snow micro-structure depend on the model. For instance, the Sticky Hard Spheres medium is implemented
+in smrt.microstructure_model.sticky_hard_spheres and its parameters are: the `radius` (required) and
+the `stickiness` (optional, default value is non-sticky, even though it is recommended to use a stickiness of ~0.1-0.3 in practice).
 
 Because IBA and SymSCE are important electromagnetic theories provided by SMRT, the first/main role of microstructure models is to provide
 the Fourier transform of the autocorrelation functions. Hence most microstructure models are named after the autocorrelation function.
-For instance, the :py:mod:`~smrt.microstructure_model.exponential` autocorrelation function is that used in MEMLS. Its only parameter is the 
+For instance, the smrt.microstructure_model.exponential autocorrelation function is that used in MEMLS. Its only parameter is the 
 `corr_length`.
 
 To use microstructure models, it is only required to read the documentation of each model to determine
@@ -18,12 +18,10 @@ module (the filename with .py). The import of the module is automatic. For insta
 
     sp = make_snowpack([1, 1000], "exponential", density=[200, 300], corr_length=[0.2e-3, 0.5e-3])
 
-This snippet creates a snowpack with the exponential autocorrelation function for all (2) layers. Import of the :py:mod:`~smrt.microstructure_model.exponential`
-is automatic and creation of instance of the class :py:mod:`~smrt.microstructure_model.exponential.Exponential` is done by the model
-:py:meth:`smrt.core.model.Model.run` method.
+This snippet creates a snowpack with the exponential autocorrelation function for all (2) layers. Import of the smrt.microstructure_model.exponential
+is automatic and creation of instance of the class smrt.microstructure_model.exponential.Exponential is done by the model
+smrt.core.model.Model.run method.
 
 The "unified" formulations are to be used with the universal parameterization set proposed in "The microwave snow grain size: a new concept to predict Satellite observations over
-snow-covered regions", AGU Advances, 3, 4, e2021AV000630, `doi:10.1029/2021AV000630
-<http://doi.org/10.1029/2021AV000630>`_.
-
- """  
+snow-covered regions", AGU Advances, 3, 4, e2021AV000630, doi:10.1029/2021AV000630.
+"""

--- a/smrt/microstructure_model/autocorrelation.py
+++ b/smrt/microstructure_model/autocorrelation.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-This module contains the base classes for the microstructure classes.
+Contains the base classes for the microstructure classes.
 **It is not used directly**.
 """
 

--- a/smrt/microstructure_model/exponential.py
+++ b/smrt/microstructure_model/exponential.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-"""Exponential autocorrelation function model of the microstructure. This microstructure model is used by MEMLS when IBA is selected.
+"""
+Implements the exponential autocorrelation function model of the microstructure. This microstructure model is used by MEMLS when IBA is selected.
 
-parameters: frac_volume, corr_length
-
+Args:
+    frac_volume (float): Fractional volume.
+    corr_length (float): Correlation length.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/gaussian_random_field.py
+++ b/smrt/microstructure_model/gaussian_random_field.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
-"""Gaussian Random field model of the microstructure.
+"""
+Implements the Gaussian Random field model of the microstructure.
 
-parameters: frac_volume, corr_length, repeat_distance
-
+Args:
+    frac_volume (float): Fractional volume.
+    corr_length (float): Correlation length.
+    repeat_distance (float): Repeat distance.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/homogeneous.py
+++ b/smrt/microstructure_model/homogeneous.py
@@ -1,9 +1,10 @@
 # coding: utf-8
 
-"""Homogeneous microstructure. This microstructure model is to be used with non-scattering emmodel.
+"""
+Implements the homogeneous microstructure. This microstructure model is to be used with non-scattering emmodel.
 
-parameters: none
-
+Args:
+    None
 """
 
 # local import

--- a/smrt/microstructure_model/independent_sphere.py
+++ b/smrt/microstructure_model/independent_sphere.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-"""Independent sphere model of the microstructure.
+"""
+Implements the independent sphere model of the microstructure.
 
-parameters: frac_volume, radius
-
+Args:
+    frac_volume (float): Fractional volume.
+    radius (float): Sphere radius.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/sampled_autocorrelation.py
+++ b/smrt/microstructure_model/sampled_autocorrelation.py
@@ -1,10 +1,10 @@
-"""Sampled autocorrelation function model. To use when no analytical form of the autocorrelation function but
-the values of the autocorrelation function (`acf`) is known at a series of `lag`.
+"""Implements the sampled autocorrelation function model. Use when no analytical form of the autocorrelation function exists but
+the values of the autocorrelation function (`acf`) are known at a series of `lag`.
 
-parameters: frac_volume, lag, acf
-
-`acf` contains the values at different `lag`. These parameters must be lists or arrays.
-
+Args:
+    frac_volume (float): Fractional volume.
+    lag (array-like): Lag values.
+    acf (array-like): Autocorrelation function values at the given lags.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/sticky_hard_spheres.py
+++ b/smrt/microstructure_model/sticky_hard_spheres.py
@@ -1,14 +1,19 @@
 # coding: utf-8
 
-"""Monodisperse sticky hard sphere model of the microstructure.
+"""
+Implements the monodisperse sticky hard sphere model of the microstructure.
 
-parameters: frac_volume, radius, stickiness.
+Args:
+    frac_volume (float): Fractional volume.
+    radius (float): Sphere radius.
+    stickiness (float, optional): Stickiness parameter. Default is 1000.
 
-The stickiness is optional but it is recommended to use value around 0.2 as a first guess.
-Be aware that low values of stickiness are invalid, the limit depends on the fractional volume
-(see for instance Loewe and Picard, 2015). See the :py:meth:`~StickyHardSpheres.tau_min` method.
+Notes:
+    The stickiness is optional but it is recommended to use value around 0.2 as a first guess.
+    Be aware that low values of stickiness are invalid, the limit depends on the fractional volume
+    (see for instance Loewe and Picard, 2015). See the tau_min method.
 
-Currently the implementation is specific to ice / snow. It can not be used for other materials.
+    Currently the implementation is specific to ice / snow. It cannot be used for other materials.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/teubner_strey.py
+++ b/smrt/microstructure_model/teubner_strey.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
-"""Teubner Strey model model of the microstructure.
+"""
+Implements the Teubner Strey model of the microstructure.
 
-parameters: frac_volume, corr_length, repeat_distance
-
+Args:
+    frac_volume (float): Fractional volume.
+    corr_length (float): Correlation length.
+    repeat_distance (float): Repeat distance.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/unified_autocorrelation.py
+++ b/smrt/microstructure_model/unified_autocorrelation.py
@@ -1,5 +1,3 @@
-
-
 # local import
 from ..core.globalconstants import DENSITY_OF_ICE
 from .autocorrelation import Autocorrelation
@@ -11,5 +9,5 @@ class UnifiedAutocorrelation(Autocorrelation):
     optional_args = {}
 
     def compute_ssa(self):
-        """compute the ssa for the given porod_length"""
+        """Compute the ssa for the given porod_length."""
         return 3 * (1 - self.frac_volume) / (DENSITY_OF_ICE * self.porod_length)

--- a/smrt/microstructure_model/unified_scaled_exponential.py
+++ b/smrt/microstructure_model/unified_scaled_exponential.py
@@ -1,10 +1,13 @@
 # coding: utf-8
 
-"""Scaled exponential autocorrelation function model of the microstructure. This microstructure uses unified parameters as defined by 
+"""
+Implements the scaled exponential autocorrelation function model of the microstructure. This microstructure uses unified parameters as defined by 
 G. Picard, H. Löwe, F. Domine, L. Arnaud, F. Larue, V. Favier, E. Le Meur, E. Lefebvre, J. Savarino, A. Royer, The snow microstructural control on microwave scattering, AGU Advances.
 
-parameters: frac_volume, porod_length, polydispersity
-
+Args:
+    frac_volume (float): Fractional volume.
+    porod_length (float): Porod length.
+    polydispersity (float): Polydispersity.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/unified_sticky_hard_spheres.py
+++ b/smrt/microstructure_model/unified_sticky_hard_spheres.py
@@ -1,10 +1,13 @@
 # coding: utf-8
 
-"""Monodisperse sticky hard sphere model of the microstructure. This microstructure uses unified parameters as defined by 
+"""
+Implements the monodisperse sticky hard sphere model of the microstructure. This microstructure uses unified parameters as defined by 
 G. Picard, H. Löwe, F. Domine, L. Arnaud, F. Larue, V. Favier, E. Le Meur, E. Lefebvre, J. Savarino, A. Royer, The snow microstructural control on microwave scattering, AGU Advances.
 
-parameters: frac_volume, porod_length, polydispersity
-
+Args:
+    frac_volume (float): Fractional volume.
+    porod_length (float): Porod length.
+    polydispersity (float): Polydispersity.
 """
 
 import numpy as np

--- a/smrt/microstructure_model/unified_teubner_strey.py
+++ b/smrt/microstructure_model/unified_teubner_strey.py
@@ -1,10 +1,13 @@
 # coding: utf-8
 
-"""Extended Teubner Strey model as described by Ruland 2010. This microstructure uses unified parameters as defined by 
+"""
+Implements the extended Teubner Strey model as described by Ruland 2010. This microstructure uses unified parameters as defined by 
 G. Picard, H. Löwe, F. Domine, L. Arnaud, F. Larue, V. Favier, E. Le Meur, E. Lefebvre, J. Savarino, A. Royer, The snow microstructural control on microwave scattering, AGU Advances.
 
-parameters: frac_volume, porod_length, polydispersity
-
+Args:
+    frac_volume (float): Fractional volume.
+    porod_length (float): Porod length.
+    polydispersity (float): Polydispersity.
 """
 
 import numpy as np

--- a/smrt/permittivity/__init__.py
+++ b/smrt/permittivity/__init__.py
@@ -1,9 +1,9 @@
 """
 Provides many formulations for the permittivity of various materials (ice, water, etc.) or for mixing
-formulae. The former are to be used as input of the functions in `smrt.inputs` in order
-to prescribe the scatterers and background permittivity, while the latter are to be used in `smrt.emmodels` to
+formulae. The former are to be used as input of the functions in :py:mod:`smrt.inputs` in order
+to prescribe the scatterers and background permittivity, while the latter are to be used in :py:mod:`smrt.emmodels` to
 reformulate how the effective permittivity is calculated. This latter usage is very specific and should not concern most
-users. See `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
+users. See :py:mod:`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
 `smrt.emmodel.iba.derived_IBA`.
 
 ..admonition:: **For developers**
@@ -32,5 +32,5 @@ users. See `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
     a function, so the need for explicit declaration.
 
     3. To use the new function, import the module (e.g. from smrt.permittivity.ice import permittivity_something) and
-    pass this function to `smrt.core.snowpack.make_snowpack` or `smrt.core.layer:make_snow_layer`.
+    pass this function to :py:mod:`smrt.core.snowpack.make_snowpack` or :py:mod:`smrt.core.layer:make_snow_layer`.
 """

--- a/smrt/permittivity/__init__.py
+++ b/smrt/permittivity/__init__.py
@@ -6,7 +6,8 @@ reformulate how the effective permittivity is calculated. This latter usage is v
 users. See :py:mod:`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
 `smrt.emmodel.iba.derived_IBA`.
 
-..admonition:: **For developers**
+..admonition:: 
+**For developers**
 
     To add a new permittivity function proceed as follows:
 

--- a/smrt/permittivity/__init__.py
+++ b/smrt/permittivity/__init__.py
@@ -17,7 +17,7 @@ users. See `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
     between the layer properties and the arguments of the function (see ice.py for examples).
     It means that the arguments of the function must be listed (in order) in the @required_layer_properties
     decorator. In most cases, the name of the arguments should be the same as a properties, but
-    this is not strictly necessary, only the order matters. For example:
+    this is not strictly necessary, only the order matters. For example::
 
         @required_layer_properties("temperature", "salinity")
         def permittivity_something(frequency, t, s):

--- a/smrt/permittivity/__init__.py
+++ b/smrt/permittivity/__init__.py
@@ -6,7 +6,7 @@ reformulate how the effective permittivity is calculated. This latter usage is v
 users. See `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
 `smrt.emmodel.iba.derived_IBA`.
 
-For developers:
+..admonition:: **For developers**
 
     To add a new permittivity function proceed as follows:
 

--- a/smrt/permittivity/__init__.py
+++ b/smrt/permittivity/__init__.py
@@ -1,13 +1,12 @@
 """
-This package provides many formulations for the permititivity of various materials (ice, water, ...) or for mixing
-formulae. It is worth noting that the formers are to be used as input of the functions in py:mod:`~smrt.inputs` in order
-to prescribe the scatterers and background permittivity, while the latters are to be used in py:mod:`~smrt.emmodels` to
+Provides many formulations for the permittivity of various materials (ice, water, etc.) or for mixing
+formulae. The former are to be used as input of the functions in `smrt.inputs` in order
+to prescribe the scatterers and background permittivity, while the latter are to be used in `smrt.emmodels` to
 reformulate how the effective permittivity is calculated. This latter usage is very specific and should not concern most
-users. See :py:func:`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
-:py:func:`smrt.emmodel.iba.derived_IBA`.
+users. See `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
+`smrt.emmodel.iba.derived_IBA`.
 
-
-.. admonition::  **For developers**
+For developers:
 
     To add a new permittivity function proceed as follows:
 
@@ -18,13 +17,13 @@ users. See :py:func:`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
     between the layer properties and the arguments of the function (see ice.py for examples).
     It means that the arguments of the function must be listed (in order) in the @required_layer_properties
     decorator. In most cases, the name of the arguments should be the same as a properties, but
-    this is not strictly necessary, only the order matters. E.g.::
+    this is not strictly necessary, only the order matters. For example:
 
-            @required_layer_properties("temperature", "salinity")
-            def permittivity_something(frequency, t, s):
+        @required_layer_properties("temperature", "salinity")
+        def permittivity_something(frequency, t, s):
 
     maps the layer property "temperature" to the argument "t" of the function (and "salinity" to s)
-    However, we recommend to change t into temperature for sake of clarity.
+    However, it is recommended to change t into temperature for sake of clarity.
 
     For curious ones, this declaration is required because the function can be called either with its arguments (normal case)
     or with only two arguments like this (frequency, layer). In this latter case, the arguments required by the original function
@@ -32,8 +31,6 @@ users. See :py:func:`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` and
     This complication is necessary because there is no way in Python to inspect the name of the arguments of
     a function, so the need for explicit declaration.
 
-    3. to use the new function, import the module (e.g. from smrt.permittivity.ice import permittivity_something) and
-    pass this function to :py:func:`smrt.core.snowpack.make_snowpack` or :py:func:`smrt.core.layer:make_snow_layer`.
-
+    3. To use the new function, import the module (e.g. from smrt.permittivity.ice import permittivity_something) and
+    pass this function to `smrt.core.snowpack.make_snowpack` or `smrt.core.layer:make_snow_layer`.
 """
-

--- a/smrt/permittivity/brine.py
+++ b/smrt/permittivity/brine.py
@@ -1,4 +1,4 @@
-"""This module contains function to compute various properties of brines.
+"""Contains functions to compute various properties of brines.
 """
 
 import warnings
@@ -13,7 +13,8 @@ from ..core.layer import layer_properties
 def brine_conductivity_stogryn85(temperature):
     """Computes ionic conductivity of dissolved salts, Stogryn and Desargant, 1985
 
-    :param temperature: thermometric temperature [K]
+    Args:
+        temperature: thermometric temperature [K]
 
     References:
         Stogryn, A., & Desargant, G. (1985). The dielectric properties of brine in sea ice at microwave frequencies. IEEE
@@ -32,7 +33,8 @@ def brine_conductivity_stogryn85(temperature):
 def brine_relaxation_time_stogryn85(temperature):
     """Computes relaxation time of brine, Stogryn and Desargant, 1985
 
-    :param temperature: thermometric temperature [K]
+    Args:
+        temperature: thermometric temperature [K]
 
     References:
         Stogryn, A., & Desargant, G. (1985). The dielectric properties of brine in sea ice at microwave frequencies. IEEE
@@ -51,8 +53,11 @@ def brine_salinity(temperature):
     """Computes the salinity of brine (in ppt) for a given temperature. The origin of this code is unknown, to be
     investigate. It was attributed to (Cox and Weeks, 1975) in earlier commits but their Eq 15 is different.
 
-    :param temperature: snow temperature in K
-    :returns: salinity_brine in ppt
+    Args:
+        temperature: snow temperature in K
+
+    Returns:
+        salinity_brine in ppt
     """
     tempC = temperature - FREEZING_POINT
 
@@ -68,8 +73,12 @@ def brine_salinity(temperature):
 def brine_salinity_coxandweeks75(temperature):
     """Computes the salinity of brine (in ppt) for a given temperature (Cox and Weeks, 1975, equation 15)
 
-    :param temperature: snow temperature in K
-    :returns: salinity_brine in ppt
+    Args:
+        temperature: snow temperature in K
+
+    Returns:
+        salinity_brine in ppt
+
     Reference: Cox, G. F. N., Wilford F. Weeks, and Cold Regions Research and Engineering Laboratory (U.S.). 1975. 
     Brine Drainage and Initial Salt Entrapment in Sodium Chloride Ice. Hanover, N.H.: 
     U.S. Dept. of Defense, Dept. of the Army, Corps of Engineers, Cold Regions Research and Engineering Laboratory.
@@ -86,8 +95,12 @@ def brine_salinity_assur60poe72(temperature):
     (Assur, 1960; Poe et al., 1972; as cited in Ulaby&Long 2014 (equation 4.46))
      Validity range:
     -43.2°C <= temperature in K <= -2°C
-    :param temperature: snow temperature in K
-    :returns: salinity_brine in psu
+    Args:
+        temperature: snow temperature in K
+
+    Returns:
+        salinity_brine in psu
+
     Reference: Ulaby, Fawwaz, and David Long. Microwave Radar and Radiometric Remote Sensing. 
     University of Michigan Press, 2014. https://doi.org/10.3998/0472119356.
 
@@ -122,7 +135,8 @@ def brine_salinity_assur60poe72(temperature):
 def static_brine_permittivity_stogryn85(temperature):
     """Computes  static dielectric constant of brine, after Stogryn and Desargant, 1985
 
-    :param temperature: thermometric temperature [K]
+    Args:
+        temperature: thermometric temperature [K]
 
     References:
         Stogryn, A., & Desargant, G. (1985). The dielectric properties of brine in sea ice at microwave frequencies. IEEE
@@ -139,7 +153,8 @@ def static_brine_permittivity_stogryn85(temperature):
 def permittivity_high_frequency_limit_stogryn85(temperature):
     """Computes permittivity.
 
-    :param temperature: ice or snow temperature in K, after Stogryn and Desargant, 1985
+    Args:
+        temperature: ice or snow temperature in K, after Stogryn and Desargant, 1985
 
     References:
         Stogryn, A., & Desargant, G. (1985). The dielectric properties of brine in sea ice at microwave frequencies. IEEE
@@ -161,7 +176,10 @@ def water_freezing_temperature(salinity):
     by a Newton-Raphson iteration of the equality of the chemical potentials of water
     in seawater and in ice.
 
-    :param salinity: salinity of ice in kg/kg (see PSU constant in smrt module)"""
+    Args:
+        salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
+
+    """
 
     # Coefficients for polynomial:
     c0 = 0.017947064327968736
@@ -209,10 +227,11 @@ def brine_volume_cox83_lepparanta88(temperature, salinity, porosity=0, bulk_dens
     J. of Glac. if ice temperature is below -2 deg C or coefficients determined by Lepparanta and Manninen (1988):
     'The brine and gas content of sea ice with attention to low salinities and high temperatures' for warmer temperatures.
 
-    :param temperature: ice temperature in K
-    :param salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
-    :param porosity: fractional air volume in ice (0..1). Default is 0.
-    :param bulk_density: density of bulk ice in kg m :sup:`-3`
+    Args:
+        temperature: ice temperature in K
+        salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
+        porosity: fractional air volume in ice (0..1). Default is 0.
+        bulk_density: density of bulk ice in kg m :sup:`-3`
 
     """
 
@@ -308,8 +327,9 @@ def brine_volume_frankenstein67(temperature, salinity):
     Garner R. Equations for Determining the Brine Volume of Sea Ice from −0.5° to −22.9°C. Journal of Glaciology.
     1967;6(48):943-944. https://doi.org:/10.3189/S0022143000020244'
 
-    :param temperature: ice temperature in K
-    :param salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
+    Args:
+        temperature: ice temperature in K
+        salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
     """
 
     S_ice = salinity  # convert from kg/kg to PSU
@@ -324,8 +344,9 @@ def brine_volume_function_stogryn_1987(temperature, salinity):
     'An analysis of the tensor dielectric constant of sea ice at microwave frequencies' (10.1109/TGRS.1987.289814),
     where the values are compared to measurements from 0 to -32 ° C and frequencies from 0.1 to 40 GHz.
 
-    :param temperature: ice temperature in K
-    :param salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
+    Args:
+        temperature: ice temperature in K
+        salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
 
     Example usage:
     salinity = 33*PSU

--- a/smrt/permittivity/generic_mixing_formula.py
+++ b/smrt/permittivity/generic_mixing_formula.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-This module contains functions that are not tied to a particular electromagnetic model
+Contains functions that are not tied to a particular electromagnetic model
 and are available to be imported by any electromagnetic model. It is the responsibility of the
 developer to ensure these functions, if used, are appropriate and consistent with the physics of the electromagnetic model.
 """
@@ -19,8 +19,11 @@ def depolarization_factors(length_ratio=None):
     """ Calculates depolarization factors for use in effective permittivity models. These
     are a measure of the anisotropy of the snow. Default is spherical isotropy.
 
-    :param length_ratio: [Optional] ratio of microstructure length measurement in x/y direction to z-direction [unitless].
-    :returns: [x, y, z] depolarization factor array
+    Args:
+        length_ratio: [Optional] ratio of microstructure length measurement in x/y direction to z-direction [unitless].
+
+    Returns:
+        [x, y, z] depolarization factor array
 
     **Usage example:**
 
@@ -57,15 +60,18 @@ def polder_van_santen(frac_volume, e0=1, eps=3.185, depol_xyz=None, length_ratio
                       inclusion_shape=None, mixing_ratio=1):
     """ Calculates effective permittivity of snow by solution of quadratic Polder Van Santen equation for spherical inclusion.
 
-    :param frac_volume: Fractional volume of inclusions
-    :param e0: Permittivity of background (default is 1)
-    :param eps: Permittivity of scattering material (default is 3.185 to compare with MEMLS)
-    :param depol_xyz: [Optional] Depolarization factors, spherical isotropy is default. It is not taken into account here.
-    :param length_ratio: Length_ratio. Used to estimate depolarization factors when they are not given.
-    :param inclusion_shape: Assumption for shape(s) of brine inclusions. Can be a string for single shape, or a list/tuple/dict of strings for mixture of shapes. So far, we have the following shapes: "spheres" and "random_needles" (i.e. randomly-oriented elongated ellipsoidal inclusions). 
-            If the argument is a dict, the keys are the shapes and the values are the mixing ratio. If it is a list, the mixing_ratio argument is required.
-    :param mixing_ratio: The mixing ratio of the shapes. This is only relevant when inclusion_shape is a list/tuple. Mixing ratio must be a sequence with length len(inclusion_shape)-1. The mixing ratio of the last shapes is deduced as the sum of the ratios must equal to 1.
-    :returns: Effective permittivity
+    Args:
+        frac_volume: Fractional volume of inclusions
+        e0: Permittivity of background (default is 1)
+        eps: Permittivity of scattering material (default is 3.185 to compare with MEMLS)
+        depol_xyz: [Optional] Depolarization factors, spherical isotropy is default. It is not taken into account here.
+        length_ratio: Length_ratio. Used to estimate depolarization factors when they are not given.
+        inclusion_shape: Assumption for shape(s) of brine inclusions. Can be a string for single shape, or a list/tuple/dict of strings for mixture of shapes. So far, we have the following shapes: "spheres" and "random_needles" (i.e. randomly-oriented elongated ellipsoidal inclusions). 
+                If the argument is a dict, the keys are the shapes and the values are the mixing ratio. If it is a list, the mixing_ratio argument is required.
+        mixing_ratio: The mixing ratio of the shapes. This is only relevant when inclusion_shape is a list/tuple. Mixing ratio must be a sequence with length len(inclusion_shape)-1. The mixing ratio of the last shapes is deduced as the sum of the ratios must equal to 1.
+
+    Returns:
+        Effective permittivity
 
     **Usage example:**
 
@@ -143,11 +149,12 @@ bruggeman = polder_van_santen
 def polder_van_santen_three_spherical_components(f1, f2, eps0, eps1, eps2):
     """Calculates effective permittivity using Polder and van Santen with three components assuming spherical inclusions
 
-    :param f1: fractional volume of component 1
-    :param f2: fractional volume of component 2
-    :param eps0: permittivity of material 0
-    :param eps1: permittivity of material 1
-    :param eps2: permittivity of material 2
+    Args:
+        f1: fractional volume of component 1
+        f2: fractional volume of component 2
+        eps0: permittivity of material 0
+        eps1: permittivity of material 1
+        eps2: permittivity of material 2
 
 """
     if (np.array(f1).ndim >= 1) or (np.array(f2).ndim >= 1):
@@ -175,13 +182,14 @@ def polder_van_santen_three_spherical_components(f1, f2, eps0, eps1, eps2):
 def polder_van_santen_three_components(f1, f2, eps0, eps1, eps2, A1, A2):
     """Calculates effective permittivity using Polder and van Santen with three components
 
-    :param f1: fractional volume of component 1
-    :param f2: fractional volume of component 2
-    :param eps0: permittivity of material 0
-    :param eps1: permittivity of material 1
-    :param eps2: permittivity of material 2
-    :param A1: depolarization factor for material 1
-    :param A2: depolarization factor for material 2
+    Args:
+        f1: fractional volume of component 1
+        f2: fractional volume of component 2
+        eps0: permittivity of material 0
+        eps1: permittivity of material 1
+        eps2: permittivity of material 2
+        A1: depolarization factor for material 1
+        A2: depolarization factor for material 2
 
 """
     if (np.array(f1).ndim >= 1) or (np.array(f2).ndim >= 1):
@@ -212,15 +220,17 @@ def polder_van_santen_three_components(f1, f2, eps0, eps1, eps2, A1, A2):
 def maxwell_garnett(frac_volume, e0, eps, depol_xyz=None, inclusion_shape=None, length_ratio=None):
     """ Calculates effective permittivity using Maxwell-Garnett equation.
 
-    :param frac_volume: Fractional volume of snow
-    :param e0: Permittivity of background (no default, must be provided)
-    :param eps: Permittivity of scattering material (no default, must be provided)
-    :param depol_xyz: [Optional] Depolarization factors, spherical isotropy is default. It is not taken into account here.
-    :param length_ratio: Length_ratio. Used to estimate depolarization factors when they are not given.
-    :param inclusion_shape: Assumption for shape(s) of brine inclusions. Can be a string for single shape, or a list/tuple/dict of strings for mixture of shapes. So far, we have the following shapes: "spheres" and "random_needles" (i.e. randomly-oriented elongated ellipsoidal inclusions). 
-            If the argument is a dict, the keys are the shapes and the values are the mixing ratio. If it is a list, the mixing_ratio argument is required.
+    Args:
+        frac_volume: Fractional volume of snow
+        e0: Permittivity of background (no default, must be provided)
+        eps: Permittivity of scattering material (no default, must be provided)
+        depol_xyz: [Optional] Depolarization factors, spherical isotropy is default. It is not taken into account here.
+        length_ratio: Length_ratio. Used to estimate depolarization factors when they are not given.
+        inclusion_shape: Assumption for shape(s) of brine inclusions. Can be a string for single shape, or a list/tuple/dict of strings for mixture of shapes. So far, we have the following shapes: "spheres" and "random_needles" (i.e. randomly-oriented elongated ellipsoidal inclusions). 
+                If the argument is a dict, the keys are the shapes and the values are the mixing ratio. If it is a list, the mixing_ratio argument is required.
 
-    :returns: random orientation effective permittivity
+    Returns:
+        random orientation effective permittivity
 
     **Usage example:**
 

--- a/smrt/permittivity/ice.py
+++ b/smrt/permittivity/ice.py
@@ -32,7 +32,7 @@ def ice_permittivity_maetzler06(frequency, temperature):
     Returns:
       complex permittivity of pure ice
 
-    Example:
+    Example::
 
       from smrt.permittivity.ice import ice_permittivity_maetzler06
       eps_ice = ice_permittivity_maetzler06(frequency=18e9, temperature=270)
@@ -116,7 +116,7 @@ def ice_permittivity_maetzler87(frequency, temperature):
     Returns:
       complex permittivity of pure ice
 
-    Example:
+    Example::
 
       from smrt.permittivity.ice import ice_permittivity_maetzler87
       eps_ice = ice_permittivity_maetzler87(frequency=18e9, temperature=270)
@@ -170,7 +170,7 @@ def ice_permittivity_tiuri84(frequency, temperature):
     Returns:
       complex permittivity of pure ice
 
-    Example:
+    Example::
 
       from smrt.permittivity.ice import ice_permittivity_tiuri84
       eps_ice = ice_permittivity_tiuri84(frequency=1.9e9, temperature=250)

--- a/smrt/permittivity/ice.py
+++ b/smrt/permittivity/ice.py
@@ -20,28 +20,30 @@ from ..core.error import SMRTError
 
 @layer_properties("temperature")
 def ice_permittivity_maetzler06(frequency, temperature):
-    """ Calculates the complex ice dielectric constant depending on the frequency and temperature.
+    """Calculates the complex ice dielectric constant depending on the frequency and temperature.
 
     Based on Mätzler, C. (2006). Thermal Microwave Radiation: Applications for Remote Sensing p456-461
     This is the default model used in smrt.inputs.make_medium.make_snow_layer().
 
-    :param frequency: frequency in Hz
-    :param temperature: temperature in K
-    :returns: complex permittivity of pure ice
+    Args:
+      frequency: frequency in Hz
+      temperature: temperature in K
 
-    Example::
+    Returns:
+      complex permittivity of pure ice
 
-        from smrt.permittivity.ice import ice_permittivity_maetzler06
-        eps_ice = ice_permittivity_maetzler06(frequency=18e9, temperature=270)
+    Example:
 
-    .. note::
+      from smrt.permittivity.ice import ice_permittivity_maetzler06
+      eps_ice = ice_permittivity_maetzler06(frequency=18e9, temperature=270)
 
-        Ice permittivity is automatically calculated in smrt.inputs.make_medium.make_snow_layer() and
-        is not set by the electromagnetic model module. An alternative
-        to ice_permittivity_maetzler06 may be specified as an argument to the make_snow_layer
-        function. The usage example is provided for external reference or testing purposes.
+    Note:
+      Ice permittivity is automatically calculated in smrt.inputs.make_medium.make_snow_layer() and
+      is not set by the electromagnetic model module. An alternative
+      to ice_permittivity_maetzler06 may be specified as an argument to the make_snow_layer
+      function. The usage example is provided for external reference or testing purposes.
 
-"""
+    """
 
     freqGHz = frequency / 1e9
 
@@ -73,8 +75,14 @@ def ice_permittivity_maetzler98(frequency, temperature):
     Maetzler (1998): 'Microwave properties of ice and snow', in B. Schmitt et al. (eds.): 'Solar system ices', p.
     241-257, Kluwer.
 
-    :param temperature: ice temperature in K
-    :param frequency: Frequency in Hz"""
+    Args:
+      temperature: ice temperature in K
+      frequency: Frequency in Hz
+
+    Returns:
+      complex permittivity of pure ice
+
+    """
 
     tempC = temperature - FREEZING_POINT
 
@@ -101,21 +109,23 @@ def ice_permittivity_maetzler87(frequency, temperature):
     Based on Mätzler, C. and Wegmüller (1987). Dielectric properties of fresh-water ice at microwave frequencies.
     J. Phys. D: Appl. Phys. 20 (1987) 1623-1630.
 
-    :param frequency: frequency in Hz
-    :param temperature: temperature in K
-    :returns: complex permittivity of pure ice
+    Args:
+      frequency: frequency in Hz
+      temperature: temperature in K
 
-    Example::
+    Returns:
+      complex permittivity of pure ice
 
-        from smrt.permittivity.ice import ice_permittivity_maetzler87
-        eps_ice = ice_permittivity_maetzler87(frequency=18e9, temperature=270)
+    Example:
 
-    .. note::
+      from smrt.permittivity.ice import ice_permittivity_maetzler87
+      eps_ice = ice_permittivity_maetzler87(frequency=18e9, temperature=270)
 
-        This is only suitable for testing at -5 deg C and -15 deg C. If used at other temperatures
-        a warning will be displayed.
+    Note:
+      This is only suitable for testing at -5 deg C and -15 deg C. If used at other temperatures
+      a warning will be displayed.
 
-"""
+    """
 
     import warnings
 
@@ -153,16 +163,19 @@ def ice_permittivity_tiuri84(frequency, temperature):
     Based on Tiuri et al. (1984). The Complex Dielectric Constant of Snow at Microwave Frequencies.
     IEEE Journal of Oceanic Engineering, vol. 9, no. 5., pp. 377-382
 
-    :param frequency: frequency in Hz
-    :param temperature: temperature in K
-    :returns: complex permittivity of pure ice
+    Args:
+      frequency: frequency in Hz
+      temperature: temperature in K
 
-    Example::
+    Returns:
+      complex permittivity of pure ice
 
-        from smrt.permittivity.ice import ice_permittivity_tiuri84
-        eps_ice = ice_permittivity_tiuri84(frequency=1.9e9, temperature=250)
+    Example:
 
-"""
+      from smrt.permittivity.ice import ice_permittivity_tiuri84
+      eps_ice = ice_permittivity_tiuri84(frequency=1.9e9, temperature=250)
+
+    """
 
     tempC = temperature - FREEZING_POINT
 
@@ -281,7 +294,7 @@ def _ice_permittivity_MEMLS(frequency, temperature, salinity):
 
 @layer_properties("temperature")
 def ice_permittivity_hufford91_maetzler87(frequency, temperature):
-    """ Calculates the complex ice dielectric constant depending on the frequency and temperature.
+    """Calculates the complex ice dielectric constant depending on the frequency and temperature.
     
     Real part of permittivity follows Mätzler and Wegmuller (1987): 
     Dielectric properties of freshwater ice at microwave frequencies, 10.1088/0022-3727/20/12/013.
@@ -290,9 +303,12 @@ def ice_permittivity_hufford91_maetzler87(frequency, temperature):
     The Hufford model is derived for frequencies up to 1000 GHz and temperatures from -40°C to 0°C.
     This gives exact agreement with the MEMLS_ice model version used in Rückert et al., 2023.
     
-    :param frequency: Frequency in Hz
-    :param temperature: ice temperature in K
-    :returns: complex permittivity of pure ice
+    Args:
+      frequency: Frequency in Hz
+      temperature: ice temperature in K
+
+    Returns:
+      complex permittivity of pure ice
     """
 
     # Raise exception if temperature is zero

--- a/smrt/permittivity/saline_ice.py
+++ b/smrt/permittivity/saline_ice.py
@@ -1,4 +1,4 @@
-"""These permittivity formulations are for use with saline ice, and possibly in some case with saline snow. See also saline_snow.py in the latter case.
+"""Provides permittivity formulations for use with saline ice, and possibly in some cases with saline snow. See also saline_snow.py in the latter case.
 """
 
 

--- a/smrt/permittivity/saline_snow.py
+++ b/smrt/permittivity/saline_snow.py
@@ -1,12 +1,12 @@
 """Provides mixing formulae relevant to saline snow. Contains equations to compute the effective permittivity of saline snow.
 
-These functions are to be used with `smrt.emmodel.iba.derived_IBA` or
+These functions are to be used with :py:mod:`smrt.emmodel.iba.derived_IBA` or
 `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
 Rayleigh, SCE) using the generic mixing formula Polder van Staten that automatically mixes the permittivities of the
 background (e.g.) and the scatterer materials (e.g. saline ice) to compute the effective permittivity of snow in a proportion
 determined by frac_volume.
 
-They should not be used to set the material permittivities as input of `smrt.smrt_inputs.make_snowpack` and
+They should not be used to set the material permittivities as input of :py:mod:`smrt.smrt_inputs.make_snowpack` and
 similar functions (because the emmodel would re-mix the already mixed materials with the background material).
 """
 

--- a/smrt/permittivity/saline_snow.py
+++ b/smrt/permittivity/saline_snow.py
@@ -1,12 +1,12 @@
-"""Mixing formulae relevant to saline snow. This module contains equations to compute the effective permittivity of saline snow.
+"""Provides mixing formulae relevant to saline snow. Contains equations to compute the effective permittivity of saline snow.
 
-These functions are to be used with :py:meth:`~smrt.emmodel.iba.derived_IBA` or
-:py:meth:`~smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
+These functions are to be used with `smrt.emmodel.iba.derived_IBA` or
+`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
 Rayleigh, SCE) using the generic mixing formula Polder van Staten that automatically mixes the permittivities of the
 background (e.g.) and the scatterer materials (e.g. saline ice) to compute the effective permittivity of snow in a proportion
 determined by frac_volume.
 
-They should not be used to set the material permittivities as input of :py:func:`~smrt.smrt_inputs.make_snowpack` and
+They should not be used to set the material permittivities as input of `smrt.smrt_inputs.make_snowpack` and
 similar functions (because the emmodel would re-mix the already mixed materials with the background material).
 """
 
@@ -31,10 +31,11 @@ def saline_snow_permittivity_geldsetzer09(frequency, density, temperature, salin
 
     Source: Matlab code, Ludovic Brucker
 
-    :param frequency: frequency in Hz
-    :param density: snow density in kg m-3
-    :param temperature: ice temperature in K
-    :param salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
+    Args:
+        frequency: frequency in Hz
+        density: snow density in kg m-3
+        temperature: ice temperature in K
+        salinity: salinity of ice in kg/kg (see PSU constant in smrt module)
     """
 
     if np.max(frequency) > 40e9:
@@ -105,10 +106,11 @@ def saline_snow_permittivity_scharien(density, temperature, salinity, brine_perm
 
     Source: Matlab code, Randall Scharien
 
-    :param density: snow density in kg m-3
-    :param temperature: snow temperature in K
-    :param salinity: snow salinity in kg/kg (see PSU constant in smrt module)
-    :param brine_permittivity: brine_permittivity
+    Args:
+        density: snow density in kg m-3
+        temperature: snow temperature in K
+        salinity: snow salinity in kg/kg (see PSU constant in smrt module)
+        brine_permittivity: brine_permittivity
 
     """
 

--- a/smrt/permittivity/saline_water.py
+++ b/smrt/permittivity/saline_water.py
@@ -18,10 +18,16 @@ def seawater_permittivity_klein76(frequency, temperature, salinity):
     """Calculates permittivity (dielectric constant) of water using an empirical relationship described
     by Klein and Swift (1976).
 
-    :param frequency: frequency in Hz
-    :param temperature: water temperature in K
-    :param salinity: water salinity in kg/kg (see PSU constant in smrt module)
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: frequency in Hz
+        temperature: water temperature in K
+        salinity: water salinity in kg/kg (see PSU constant in smrt module)
+
+    Returns:
+        complex water permittivity for a frequency f.
+
+    Raises:
+        SMRTError: If the water temperature is lower than the freezing point at the given salinity.
 
     """
 
@@ -73,14 +79,17 @@ def seawater_permittivity_stogryn71(frequency, temperature):
 
     Source: Matlab code, Ludovic Brucker
 
-    :param frequency: frequency in Hz
-    :param temperature: water temperature in K
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: frequency in Hz
+        temperature: water temperature in K
+
+    Returns:
+        complex water permittivity for a frequency f.
 
     References:
-    A. Stogryn, "Equations for Calculating the Dielectric Constant of Saline Water (Correspondence)," in IEEE
-    Transactions on Microwave Theory and Techniques, vol. 19, no. 8, pp. 733-736, Aug. 1971, doi:
-    10.1109/TMTT.1971.1127617
+        A. Stogryn, "Equations for Calculating the Dielectric Constant of Saline Water (Correspondence)," in IEEE
+        Transactions on Microwave Theory and Techniques, vol. 19, no. 8, pp. 733-736, Aug. 1971, doi:
+        10.1109/TMTT.1971.1127617
 
     """
 
@@ -114,9 +123,12 @@ def brine_permittivity_stogryn85(frequency, temperature):
     """Computes permittivity and loss of brine using equations given in Stogryn and Desargant (1985): 'The Dielectric
     Properties of Brine in Sea Ice at Microwave Frequencies', IEEE.
 
-    :param frequency: em frequency [Hz]
-    :param temperature: ice temperature in K
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: em frequency [Hz]
+        temperature: ice temperature in K
+
+    Returns:
+        complex water permittivity for a frequency f.
 
     """
 
@@ -138,10 +150,13 @@ def seawater_permittivity_stogryn95(frequency, temperature, salinity):
 
     source: Stogryn 1995 + http://rime.aos.wisc.edu/MW/models/src/eps_sea_stogryn.f90; Matlab code, Ludovic Brucker
 
-    :param frequency: frequency in Hz
-    :param temperature: water temperature in K
-    :param salinity: water salinity in kg/kg (see PSU constant in smrt module)
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: frequency in Hz
+        temperature: water temperature in K
+        salinity: water salinity in kg/kg (see PSU constant in smrt module)
+
+    Returns:
+        complex water permittivity for a frequency f.
 
     """
 
@@ -233,9 +248,12 @@ def seawwater_permittivity_boutin21_2function(frequency, temperature, salinity):
 
     This function requires the Gibbs SeaWater Oceanographic Toolbox package (gsw): https://github.com/TEOS-10/GSW-python
 
-    :param frequency: em frequency [Hz]
-    :param temperature: ice temperature in K
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: em frequency [Hz]
+        temperature: ice temperature in K
+
+    Returns:
+        complex water permittivity for a frequency f.
 
     """
     import gsw
@@ -312,9 +330,12 @@ def seawwater_permittivity_boutin21_3function(frequency, temperature, salinity):
 
     This function requires the Gibbs SeaWater Oceanographic Toolbox package (gsw): https://github.com/TEOS-10/GSW-python
 
-    :param frequency: em frequency [Hz]
-    :param temperature: ice temperature in K
-    :returns: complex water permittivity for a frequency f.
+    Args:
+        frequency: em frequency [Hz]
+        temperature: ice temperature in K
+
+    Returns:
+        complex water permittivity for a frequency f.
 
     """
 

--- a/smrt/permittivity/snow_mixing_formula.py
+++ b/smrt/permittivity/snow_mixing_formula.py
@@ -2,13 +2,13 @@
 
 """Provides mixing formulae relevant to snow. Contains equations to compute the effective permittivity of snow.
 
-These functions are to be used with `smrt.emmodel.iba.derived_IBA` or
+These functions are to be used with :py:mod:`smrt.emmodel.iba.derived_IBA` or
 `smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
 Rayleigh, SCE) using the generic mixing formula Polder van Staten that automatically mixes the permittivities of the
 background (e.g.) and the scatterer materials (e.g. ice) to compute the effective permittivity of snow in a proportion
 determined by frac_volume.
 
-They should not be used to set the material permittivities as input of `smrt.smrt_inputs.make_snowpack` and
+They should not be used to set the material permittivities as input of :py:mod:`smrt.smrt_inputs.make_snowpack` and
 similar functions (because the emmodel would re-mix the already mixed materials with the background material).
 """
 

--- a/smrt/permittivity/snow_mixing_formula.py
+++ b/smrt/permittivity/snow_mixing_formula.py
@@ -1,16 +1,14 @@
-
 # coding: utf-8
 
-"""Mixing formulae relevant to snow. This module contains equations to compute the effective permittivity of snow.
-Many semi-empirical mixing formulae have been developed for specific mixture of two, three or more materials (e.g. snow).
+"""Provides mixing formulae relevant to snow. Contains equations to compute the effective permittivity of snow.
 
-These functions are to be used with py:meth:`~smrt.emmodel.iba.derived_IBA` or
-py:meth:`~smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
+These functions are to be used with `smrt.emmodel.iba.derived_IBA` or
+`smrt.emmodel.symsce_torquato21.derived_SymSCETK21` to change the default of most emmodels (IBA, DMRT, SFT
 Rayleigh, SCE) using the generic mixing formula Polder van Staten that automatically mixes the permittivities of the
 background (e.g.) and the scatterer materials (e.g. ice) to compute the effective permittivity of snow in a proportion
 determined by frac_volume.
 
-They should not be used to set the material permittivities as input of py:meth:`~smrt.smrt_inputs.make_snowpack` and
+They should not be used to set the material permittivities as input of `smrt.smrt_inputs.make_snowpack` and
 similar functions (because the emmodel would re-mix the already mixed materials with the background material).
 """
 

--- a/smrt/permittivity/water.py
+++ b/smrt/permittivity/water.py
@@ -13,10 +13,15 @@ def water_permittivity_maetzler87(frequency, temperature):
      Based on Mätzler, C., & Wegmuller, U. (1987). Dielectric properties of freshwater
      ice at microwave frequencies. *Journal of Physics D: Applied Physics*, 20(12), 1623-1630.
 
-     :param frequency: frequency in Hz
-     :param temperature: temperature in K
-     :raises Exception: if liquid water > 0 or salinity > 0 (model unsuitable)
-     :returns: complex permittivity of pure ice
+     Args:
+         frequency: Frequency in Hz.
+         temperature: Temperature in K.
+
+     Raises:
+         Exception: If liquid water > 0 or salinity > 0 (model unsuitable).
+
+     Returns:
+         complex: Complex permittivity of pure ice.
 """
     if temperature < FREEZING_POINT:
         raise SMRTError(f"The water temperature must be higher or equal to {FREEZING_POINT}K")
@@ -52,7 +57,16 @@ def water_permittivity_tiuri80(frequency, temperature):
 
     https://ntrs.nasa.gov/api/citations/19810010984/downloads/19810010984.pdf
 
-"""
+    Args:
+        frequency: Frequency in Hz.
+        temperature: Temperature in K.
+
+    Raises:
+        SMRTError: If the water temperature is below the freezing point.
+
+    Returns:
+        complex: Complex permittivity of water.
+    """
     freqGHz = frequency / GHz
 
     tempC = temperature - FREEZING_POINT

--- a/smrt/permittivity/wetice.py
+++ b/smrt/permittivity/wetice.py
@@ -14,12 +14,15 @@ def wetice_permittivity_bohren83(frequency, temperature, liquid_water):
 
     See also: K L CHOPRA and G B REDDY, Praman.a- Optically selective coatings, J. Phys., Vol. 27, Nos 1 & 2, July & August 1986, pp. 193-217.
 
-    :param frequency: frequency in Hz.
-    :param temperature: temperature in K.
-    :param liquid_water: (fractional volume of water with respect to ice+water volume).
-    :returns: complex permittivity of pure ice.
+    Args:
+        frequency: Frequency in Hz.
+        temperature: Temperature in K.
+        liquid_water: Fractional volume of water with respect to ice+water volume.
 
-"""
+    Returns:
+        Complex permittivity of pure ice.
+
+    """
 
     epsice = ice_permittivity_maetzler06(frequency, temperature)
 
@@ -36,12 +39,15 @@ def symmetric_wetice_permittivity(frequency, temperature, liquid_water):
     """Calculate the dielectric constant of wet particules of ice using Polder van Santen Maxwell equation 
     assuming both ice and water are fully mixed. This applies to intermediate content of wetness. Typically liquid_water=0.5.
 
-    :param frequency: frequency in Hz.
-    :param temperature: temperature in K.
-    :param liquid_water: (fractional volume of water with respect to ice+water volume).
-    :returns: complex permittivity of pure ice.
+    Args:
+        frequency: Frequency in Hz.
+        temperature: Temperature in K.
+        liquid_water: Fractional volume of water with respect to ice+water volume.
 
-"""
+    Returns:
+        Complex permittivity of pure ice.
+
+    """
 
     epsice = ice_permittivity_maetzler06(frequency, temperature)
 

--- a/smrt/permittivity/wetsnow.py
+++ b/smrt/permittivity/wetsnow.py
@@ -16,10 +16,13 @@ warnings.warn("The wetsnow module is to be removed in a future version."
 def wetsnow_permittivity(frequency, temperature, liquid_water):
     """Calculate the dielectric constant of wet particles of ice using Bohren and Huffman 1983 according to Ya Qi Jin, eq 8-69, 1996 p282.
 
-    :param frequency: frequency in Hz
-    :param temperature: temperature in K
-    :param liquid_water: (fractional volume of water with respect to ice+water volume)
-    :returns: complex permittivity of pure ice
+    Args:
+        frequency: frequency in Hz
+        temperature: temperature in K
+        liquid_water: fractional volume of water with respect to ice+water volume
+
+    Returns:
+        complex permittivity of pure ice
 
     """
     # from http://books.google.com/books?id=Y_-113zIvgkC&pg=PA142&lpg=PA142&dq=effective+dielectric+constant+sphere+coated+small&source=bl&ots=ZVfwvkA0K1&sig=P7fHb0Jff8C-7-GrlEnWRZkkxY8&hl=en&ei=RHfDTrmjJYXj8AO3v7ScCw&sa=X&oi=book_result&ct=result&resnum=3&ved=0CDYQ6AEwAg#v=onepage&q=effective%20dielectric%20constant%20sphere%20coated%20small&f=false

--- a/smrt/rtsolver/__init__.py
+++ b/smrt/rtsolver/__init__.py
@@ -8,7 +8,8 @@ in most cases unless the computation time is a constraint.
 
 Selection of the solver is done with the :py:mod:`smrt.core.model.make_model` function.
 
-For Developers:
+Note:  **For Developers**
+
     To experiment with DORT, it is recommended to copy the file dort.py to e.g. dort_mytest.py so it is immediately available through
     :py:mod:`smrt.core.model.make_model`.
 

--- a/smrt/rtsolver/__init__.py
+++ b/smrt/rtsolver/__init__.py
@@ -1,20 +1,18 @@
 """
-This package contains different solvers of the radiative transfer equation. Based on the electromagnetic properties of
+Contains different solvers of the radiative transfer equation. Based on the electromagnetic properties of
 each layer computed by the EM model, these RT solvers compute the emission and propagation of energy in the medium up to the surface (the atmosphere is usually
-dealt with independently in dedicated modules in :py:mod:`smrt.atmosphere`).
+dealt with independently in dedicated modules in `smrt.atmosphere`).
 
 The solvers differ by the approximations and numerical methods. :py:mod:`~smrt.rtsolver.dort` is currently the most accurate and recommended
 in most cases unless the computation time is a constraint.
 
-The selection of the solver is done with the :py:func:`~smrt.core.model.make_model` function.
+Selection of the solver is done with the `smrt.core.model.make_model` function.
 
-.. admonition:: **For Developers**
+For Developers:
+    To experiment with DORT, it is recommended to copy the file dort.py to e.g. dort_mytest.py so it is immediately available through
+    `smrt.core.model.make_model`.
 
-    To experiment with DORT, we recommand to copy the file dort.py to e.g. dort_mytest.py so it is immediately available through
-    :py:func:`~smrt.core.model.make_model`.
-
-    To develop a new solver that will be accessible by the :py:func:`~smrt.core.model.make_model` function, you need to add
-    a file in this directory, give a look at dort.py which is not simple but the only one at the moment. Only the method solve needs
-    to be implemented. It must return a :py:class:`~smrt.core.result.Result` instance with the results. Contact the core developers to have more details.
-
- """
+    To develop a new solver that will be accessible by the `smrt.core.model.make_model` function, add
+    a file in this directory. Refer to dort.py as an example. Only the `solve` method needs
+    to be implemented. It must return a `smrt.core.result.Result` instance with the results. Contact the core developers for more details.
+"""

--- a/smrt/rtsolver/__init__.py
+++ b/smrt/rtsolver/__init__.py
@@ -1,18 +1,18 @@
 """
 Contains different solvers of the radiative transfer equation. Based on the electromagnetic properties of
 each layer computed by the EM model, these RT solvers compute the emission and propagation of energy in the medium up to the surface (the atmosphere is usually
-dealt with independently in dedicated modules in `smrt.atmosphere`).
+dealt with independently in dedicated modules in :py:mod:`smrt.atmosphere`).
 
 The solvers differ by the approximations and numerical methods. :py:mod:`~smrt.rtsolver.dort` is currently the most accurate and recommended
 in most cases unless the computation time is a constraint.
 
-Selection of the solver is done with the `smrt.core.model.make_model` function.
+Selection of the solver is done with the :py:mod:`smrt.core.model.make_model` function.
 
 For Developers:
     To experiment with DORT, it is recommended to copy the file dort.py to e.g. dort_mytest.py so it is immediately available through
-    `smrt.core.model.make_model`.
+    :py:mod:`smrt.core.model.make_model`.
 
-    To develop a new solver that will be accessible by the `smrt.core.model.make_model` function, add
+    To develop a new solver that will be accessible by the :py:mod:`smrt.core.model.make_model` function, add
     a file in this directory. Refer to dort.py as an example. Only the `solve` method needs
-    to be implemented. It must return a `smrt.core.result.Result` instance with the results. Contact the core developers for more details.
+    to be implemented. It must return a :py:mod:`smrt.core.result.Result` instance with the results. Contact the core developers for more details.
 """

--- a/smrt/rtsolver/dort.py
+++ b/smrt/rtsolver/dort.py
@@ -19,7 +19,7 @@ Note:
     The DORT solver is very robust in passive mode but may raise exception in active mode due to a matrix
     diagonalisation problem. The exception provides detailed information on how to address this issue. Two new
     diagonalisation approaches were added in January 2024. They are activated by setting the diagonalization_method optional
-    argument (see `smrt.core.make_model`). The first method (diagonalization_method='shur') replaces the
+    argument (see :py:mod:`smrt.core.make_model`). The first method (diagonalization_method='shur') replaces the
     scipy.linalg.eig function by a shur decomposition followed by a diagonalisation of the shur matrix. While
     scipy.linalg.eig performs such a shur decomposition internally in any case, it seems that explicitly calling the shur
     decomposition beforehand improves the stability. Nevertheless to really solve the problem, the second method

--- a/smrt/rtsolver/dort.py
+++ b/smrt/rtsolver/dort.py
@@ -1,39 +1,40 @@
 # coding: utf-8
 
-"""The Discrete Ordinate and Eigenvalue Solver is a multi-stream solver of the radiative transfer model. It is precise
-but less efficient  than 2 or 6 flux solvers. Different flavours of DORT (or DISORT) exist depending on the mode
+"""Provides the Discrete Ordinate and Eigenvalue Solver as a multi-stream solver of the radiative transfer model.
+
+Solvers are precise but less efficient than 2 or 6 flux solvers. Different flavours of DORT (or DISORT) exist depending on the mode
 (passive or active), on the density of the medium (sparse media have trivial inter-layer boundary conditions), on the
 way the streams are connected between the layers and on the way the phase function is prescribed. The actual version is
 a blend between Picard et al. 2004 (active mode for sparse media) and DMRT-ML (Picard et al. 2013) which works in
 passive mode only for snow. The DISORT often used in optics (Stamnes et al. 1988) only works for sparse medium and uses
-a development of the phase function in Legendre polynomia on theta. The version used in DMRT-QMS (L. Tsang's group) is
+a development of the phase function in Legendre polynomials on theta. The version used in DMRT-QMS (L. Tsang's group) is
 similar to the present implementation except it uses spline interpolation to connect constant-angle streams between the
-layers although we use direct connection by varying the angle  according to Snell's law. A practical consequence is that
+layers although we use direct connection by varying the angle according to Snell's law. A practical consequence is that
 the number of streams vary (due to internal reflection) and the value `n_max_stream` only applies in the most refringent
 layer. The number of outgoing streams in the air is usually smaller, sometimes twice smaller (depends on the density
-profile). It is important not to set too low a value for n_max_streams. E.g. 32 is usually fine, 64 or 128 are better
+profile). It is important not to set too low a value for n_max_stream. E.g. 32 is usually fine, 64 or 128 are better
 but simulations will be much slower.
 
-.. note:: The DORT solver is very robust in passive mode but may raise exception in active mode due to a matrix
-    diagonlisation problem. The exception provides detailed information on how to address this issue. Two new
-    diagonalisation approches were added in Januray 2024. They are activated by setting the diagonalization_method optional
-    argument (see :py:meth:`smrt.core.make_model`). The first method (diagonalization_method='shur') replaces the
-    scipy.linalg.eig function by a shur decomposition followed by a diagionalisation of the shur matrix. While
+Note:
+    The DORT solver is very robust in passive mode but may raise exception in active mode due to a matrix
+    diagonalisation problem. The exception provides detailed information on how to address this issue. Two new
+    diagonalisation approaches were added in January 2024. They are activated by setting the diagonalization_method optional
+    argument (see `smrt.core.make_model`). The first method (diagonalization_method='shur') replaces the
+    scipy.linalg.eig function by a shur decomposition followed by a diagonalisation of the shur matrix. While
     scipy.linalg.eig performs such a shur decomposition internally in any case, it seems that explicitly calling the shur
     decomposition beforehand improves the stability. Nevertheless to really solve the problem, the second method
-    (diagonalization_method='shur_forcedtriu') consists in removing the 2x2 and 3x3 blocks from the shur matrix, ie. forcing
-    the shur matrix to be upper triangular (triu in numpy jargon =zeroing the lower part of this
+    (diagonalization_method='shur_forcedtriu') consists in removing the 2x2 and 3x3 blocks from the shur matrix, i.e. forcing
+    the shur matrix to be upper triangular (triu in numpy jargon = zeroing the lower part of this
     matrix). This problem is due to the structure of the matrix to be diagonalized and the formulation of the DORT method in the polarimetric
-    configuration. The eigenvalues come by triplets and can be very close to each other for the three H, V, U Stockes components
+    configuration. The eigenvalues come by triplets and can be very close to each other for the three H, V, U Stokes components
     when scattering is becoming small (or equiv. the azimuth mode 'm' is large). As a consequence of the Gershgorin theorem,
     this results in slightly complex eigenvalues (i.e. eigenvalues with very small imaginary part) that comes from 2x2 or
     3x3 blocks in the shur decomposition. This would not be a problem if the eigenvectors were correctly estimated, but this
     is not the case. It is indeed difficult to find the correct orientation of eigenvectors associated to very close
     eigenvalues. To overcome the problem, the solution is to remove the 2x2 and 3x3 blocks. In principle, it would be safer
     to check that these blocks are nearly diagonal but this is not done in the current implementation. The user is
-    reponsabible to switch between the options until it works. After sufficient successfull reports by user will be received the last
-    method (forcedtriu) will certainly be the defaut.
-
+    responsible to switch between the options until it works. After sufficient successful reports by users are received the last
+    method (forcedtriu) will certainly be the default.
 """
 
 
@@ -58,7 +59,7 @@ from smrt.core.optional_numba import numba
 
 
 class DORT(object):
-    """Discrete Ordinate and Eigenvalue Solver
+    """Implements the Discrete Ordinate and Eigenvalue Solver.
 
     :param n_max_stream: number of stream in the most refringent layer
     :param m_max: number of mode (azimuth)
@@ -117,9 +118,17 @@ class DORT(object):
         self.prune_deep_snowpack = prune_deep_snowpack
 
     def solve(self, snowpack, emmodels, sensor, atmosphere=None):
-        """solve the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
+        """Solves the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
 
-"""
+        Args:
+            snowpack: Snowpack object.
+            emmodels: List of electromagnetic models.
+            sensor: Sensor object.
+            atmosphere: Optional atmosphere object.
+
+        Returns:
+            Result: Computed result.
+        """
         try:
             len(self.sensor.phi)
         except Exception:

--- a/smrt/rtsolver/dort_nonormalization.py
+++ b/smrt/rtsolver/dort_nonormalization.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
-"""The Discrete Ordinate and Eigenvalue Solver is a multi-stream solver of the radiative transfer model. It is precise but less efficient 
-than 2 or 6 flux solvers. Different flavours of DORT (or DISORT) exist depending on the mode (passive or active), on the density of the medium
+"""Provides a Discrete Ordinate and Eigenvalue Solver as a multi-stream solver of the radiative transfer model.
+
+Solvers are precise but less efficient than 2 or 6 flux solvers. Different flavours of DORT (or DISORT) exist depending on the mode (passive or active), on the density of the medium
 (sparse media have trivial inter-layer boundary conditions), on the way the streams are connected between the layers and on the way the phase
 function is prescribed. The actual version is a blend between Picard et al. 2004 (active mode for sparse media) and DMRT-ML (Picard et al. 2013) which works
 in passive mode only for snow. The DISORT often used in optics (Stamnes et al. 1988) works only for sparse medium and uses a development of the phase
@@ -10,7 +11,6 @@ it uses spline interpolation to connect constant-angle streams between the layer
 according to Snell's law. A practical consequence is that the number of streams vary (due to internal reflection) and the value `n_max_stream`
 only applies in the most refringent layer. The number of outgoing streams in the air is usually smaller, sometimes twice smaller (depends on the density profile).
 It is important not to set too low a value for n_max_stream. E.g. 32 is usually fine, 64 or 128 are better but simulations will be much slower.
-
 """
 
 
@@ -32,11 +32,12 @@ from ..core.lib import is_equal_zero
 
 
 class DORT(object):
-    """Discrete Ordinate and Eigenvalue Solver
+    """Implements the Discrete Ordinate and Eigenvalue Solver.
 
-        :param n_max_stream: number of stream in the most refringent layer
-        :param m_max: number of mode (azimuth)
-
+    Args:
+        n_max_stream (int): Number of streams in the most refringent layer.
+        m_max (int): Number of mode (azimuth).
+        stream_mode (str): Stream mode, default is "most_refringent".
     """
 
     # this specifies which dimension this solver is able to deal with. Those not in this list must be managed by the called (Model object)
@@ -54,9 +55,17 @@ class DORT(object):
         self.m_max = m_max
 
     def solve(self, snowpack, emmodels, sensor, atmosphere=None):
-        """solve the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
+        """Solves the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
 
-"""
+        Args:
+            snowpack: Snowpack object.
+            emmodels: List of electromagnetic models.
+            sensor: Sensor object.
+            atmosphere: Optional atmosphere object.
+
+        Returns:
+            Result: Computed result.
+        """
         try:
             len(self.sensor.phi)
         except Exception:

--- a/smrt/rtsolver/nadir_lrm_altimetry.py
+++ b/smrt/rtsolver/nadir_lrm_altimetry.py
@@ -10,7 +10,7 @@ Approximations:
 
 Note:
     With this RT solver, if using Geometrical Optics for rough surface/interface modeling, it is strongly advised to use
-    `smrt.interface.geometrical_optics_backscatter` instead of `smrt.interface.geometrical_optics` for
+    :py:mod:`smrt.interface.geometrical_optics_backscatter` instead of :py:mod:`smrt.interface.geometrical_optics` for
     the reason explained in the documentation of those modules.
 """
 

--- a/smrt/rtsolver/nadir_lrm_altimetry.py
+++ b/smrt/rtsolver/nadir_lrm_altimetry.py
@@ -1,19 +1,18 @@
-"""Nadir LRM Mode Altimetry rtsolver computes waveforms as measured by Low Rate Mode altimeters (e.g. ENVISAT) for the
-given snowpack and sensor (or complex terrain soon). I was based on Adams and Brown 1998 and Lacroix et al. 2008. Both
+"""Computes waveforms as measured by Low Rate Mode altimeters (e.g. ENVISAT) for the
+given snowpack and sensor (or complex terrain soon). The implementation is based on Adams and Brown 1998 and Lacroix et al. 2008. Both
 models differ in the specific choices for the scattering and backscatter of the interface, but are similar in the way
 the waveform is calculated, which concerns the solver here.
 
 Approximations:
- - Backscatter is computed assuming only first order scattering. The propagation is then simply governed by extinction
- - Near nadir / small angle approximation: to compute delay, the paths in the snow are along the z-axis. We neglect the off-nadir delay.*
- This error is likely to be small (except for very deep penetration).
+    - Backscatter is computed assuming only first order scattering. The propagation is then simply governed by extinction.
+    - Near nadir / small angle approximation: to compute delay, the paths in the snow are along the z-axis. Off-nadir delay is neglected.
+      This error is likely to be small (except for very deep penetration).
 
-.. note:
+Note:
     With this RT solver, if using Geometrical Optics for rough surface/interface modeling, it is strongly advised to use
-    :py:mod:`~smrt.interface.geometrical_optics_backscatter` instead of :py:mod:`~smrt.interface.geometrical_optics` for
+    `smrt.interface.geometrical_optics_backscatter` instead of `smrt.interface.geometrical_optics` for
     the reason explained in the documentation of those modules.
-
- """
+"""
 
 import numpy as np
 import scipy.signal
@@ -29,7 +28,7 @@ import xarray as xr
 
 
 class NadirLRMAltimetry(object):
-    """Nadir LRM Mode Altimetry rtsolver
+    """Implements the Nadir LRM Mode Altimetry RT solver.
 
     :param oversampling: integer number defining the number of subgates used for the computation in each altimeter gate.
         This is equivalent to multiply the bandwidth by this number. It is used to perform more accurate computation.
@@ -79,9 +78,17 @@ class NadirLRMAltimetry(object):
             self.return_theta_inc_sampling = False
 
     def solve(self, snowpack, emmodels, sensor, atmosphere=None):
-        """solve the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
+        """Solves the radiative transfer equation for a given snowpack, emmodels and sensor configuration.
 
-"""
+        Args:
+            snowpack: Snowpack object.
+            emmodels: List of electromagnetic models.
+            sensor: Sensor object.
+            atmosphere: Optional atmosphere object.
+
+        Returns:
+            AltimetryResult: Computed result.
+        """
         if sensor.theta_inc != 0:
             raise SMRTError("This solver is for nadir looking altimeter only")
         assert atmosphere is None
@@ -280,6 +287,8 @@ class NadirLRMAltimetry(object):
 
         :param mu: cosine of the incidence angles. Only the dependence on the surface scattering depend on mu_i
 
+        Returns:
+            ndarray: Backscattering distribution.
         """
         mu_i = np.atleast_1d(mu_i)
 

--- a/smrt/rtsolver/nadir_lrm_altimetry.py
+++ b/smrt/rtsolver/nadir_lrm_altimetry.py
@@ -10,7 +10,7 @@ Approximations:
 
 Note:
     With this RT solver, if using Geometrical Optics for rough surface/interface modeling, it is strongly advised to use
-    :py:mod:`smrt.interface.geometrical_optics_backscatter` instead of :py:mod:`smrt.interface.geometrical_optics` for
+    :py:func:`smrt.interface.geometrical_optics_backscatter` instead of :py:func:`smrt.interface.geometrical_optics` for
     the reason explained in the documentation of those modules.
 """
 

--- a/smrt/rtsolver/waveform_model.py
+++ b/smrt/rtsolver/waveform_model.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import scipy.special
 
@@ -10,9 +9,15 @@ class WaveformModel(object):
 
 
 class Brown1977(WaveformModel):
-    """Antenna Gain formulation used by Brown 1977. The formula is exp(2/gamma * sin(theta)**2) for the perfect nadir case,
-but is also available with off-nadir angles.
-"""
+    """Implements the Antenna Gain formulation used by Brown 1977.
+
+    The formula is exp(2/gamma * sin(theta)**2) for the perfect nadir case,
+    but is also available with off-nadir angles.
+
+    Args:
+        sensor: Sensor object.
+        numerical_convolution (bool): Whether to use numerical convolution.
+    """
     __name__ = "brown_1977"
 
     def __init__(self, sensor, numerical_convolution=False):
@@ -66,12 +71,16 @@ but is also available with off-nadir angles.
                 * scipy.special.i0(4 / self.gamma * np.sqrt(e) * np.sin(2 * theta))
 
     def PFS_PTR_PDF(self, tau, sigma_surface=0, surface_slope=0):
-        """compute the convolution of the PFS and PTR
+        """Computes the convolution of the PFS and PTR.
 
-        :param sensor: sensor to apply the antenna gain
-        :param tau: time to which to compute the PFSxPTR
-        :param sigma_surface: RMS height of the surface topography (meter)
-"""
+        Args:
+            tau: Time to which to compute the PFSxPTR.
+            sigma_surface (float): RMS height of the surface topography (meter).
+            surface_slope (float): Surface slope.
+
+        Returns:
+            ndarray: Convoluted PFS and PTR.
+        """
 
         sqrt2 = 1.4142135623731
         sigma_c = np.sqrt(self.sensor.pulse_sigma**2 + (2 * sigma_surface / C_SPEED)**2)
@@ -101,7 +110,9 @@ but is also available with off-nadir angles.
 
 
 class Newkrik1992(WaveformModel):
-    """Antenna Gain formulation proposed by Newkrik and Brown, 1992. Compared to the classical Bronw 1977, it takes into account 
+    """Implements the Antenna Gain formulation proposed by Newkrik and Brown, 1992.
+
+    Compared to the classical Brown 1977, it takes into account 
     the asymmetry of the antenna pattern in the co and cross-track direction.
 
 """

--- a/smrt/runner/celery_runner.py
+++ b/smrt/runner/celery_runner.py
@@ -1,7 +1,8 @@
 """Run the simulations using Celery on a cluster. This requires  setup on the cluster
 (see the Celery documentation https://docs.celeryproject.org/).
 
-Example:
+Example::
+
     from smrt.runner.celery import CeleryParallelRunner
 
     runner = CeleryParallelRunner()   # Run with the default broker redis://localhost:6379/0 but any url can be provided, as well as a Celery object

--- a/smrt/runner/celery_runner.py
+++ b/smrt/runner/celery_runner.py
@@ -1,16 +1,14 @@
 """Run the simulations using Celery on a cluster. This requires  setup on the cluster
 (see the Celery documentation https://docs.celeryproject.org/).
 
-Example::
-
+Example:
     from smrt.runner.celery import CeleryParallelRunner
 
-    runner = CeleryParallelRunner()   # run with the default broker redis://localhost:6379/0 but any url can be provided, as well as a Celery object
+    runner = CeleryParallelRunner()   # Run with the default broker redis://localhost:6379/0 but any url can be provided, as well as a Celery object
 
     m = make_model(...)
 
     m.run(sensor, snowpack, runner=runner)
-
 """
 
 
@@ -34,9 +32,9 @@ class CeleryParallelRunner(object):
     def __init__(self, broker="redis://localhost:6379", chunk=10):
         """prepare a dask runner.
 
-        :param broker: the url or a Celery object (app)
-        :param chunk: size of the chunk to transmit to the runner
-
+        Args:
+            broker (str or Celery): The url or a Celery object (app).
+            chunk (int): Size of the chunk to transmit to the runner.
         """
 
         super().__init__()

--- a/smrt/runner/dask_runner.py
+++ b/smrt/runner/dask_runner.py
@@ -1,16 +1,14 @@
 """Run the simulations using dask.distributed on a cluster. This requires  setup on the cluster
 (see the dask.distributed documentation).
 
-Example::
-
+Example:
     from smrt.runner.dask import DaskParallelRunner
 
-    runner = DaskParallelRunner()   # run on localhost:7454 by default but an url can be provided
+    runner = DaskParallelRunner()   # Run on localhost:7454 by default but an url can be provided
 
     m = make_model(...)
 
     m.run(sensor, snowpack, runner=runner)
-
 """
 
 
@@ -23,12 +21,12 @@ class DaskParallelRunner(object):
     """
 
     def __init__(self, progressbar=False, client="localhost:7454", chunk=10):
-        """prepare a dask runner.
+        """Prepares a dask runner.
 
-        :param progressbar: show a progress bar if True (not available for DaskparalleRunner)
-        :param client: the url or a dask client objbect
-        :param chunk: size of the chunk to transmit to the runner
-
+        Args:
+            progressbar (bool): Shows a progress bar if True (not available for DaskParallelRunner).
+            client (str or Client): The url or a dask client object.
+            chunk (int): Size of the chunk to transmit to the runner.
         """
 
         super().__init__()

--- a/smrt/runner/dask_runner.py
+++ b/smrt/runner/dask_runner.py
@@ -1,7 +1,8 @@
 """Run the simulations using dask.distributed on a cluster. This requires  setup on the cluster
 (see the dask.distributed documentation).
 
-Example:
+Example::
+
     from smrt.runner.dask import DaskParallelRunner
 
     runner = DaskParallelRunner()   # Run on localhost:7454 by default but an url can be provided

--- a/smrt/substrate/__init__.py
+++ b/smrt/substrate/__init__.py
@@ -5,11 +5,10 @@ This is usually the soil, ice, or water but can also be an aluminium plate or an
 
 To create a substrate, use or implement a helper function such as smrt.inputs.make_soil.make_soil. This function is able to automatically load a specific soil model.
 
-Examples:
-    ```python
+Examples::
+
     from smrt import make_soil
     soil = make_soil("soil_wegmuller", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100, roughness_rms=1e-2)
-    ```
 
 It is recommended to first read the documentation of smrt.inputs.make_soil.make_soil and then explore the different types of soil models.
 
@@ -17,5 +16,4 @@ It is recommended to first read the documentation of smrt.inputs.make_soil.make_
 
     To develop a new substrate formulation, you must add a file in the smrt/substrate directory. The name of the file is used by make_soil
     to build the substrate object.
-
- """
+"""

--- a/smrt/substrate/__init__.py
+++ b/smrt/substrate/__init__.py
@@ -1,19 +1,17 @@
-
 """
+Contains different options to represent the substrate, that is, the lower boundary conditions of the radiative transfer equation.
 
-This package contains different options to represent the substrate, that is the lower boundary conditions of the radiative transfer equation.
-This is usually the soil, ice or water but can also be an aluminium plate or an absorber.
+This is usually the soil, ice, or water but can also be an aluminium plate or an absorber.
 
-To create a substrate, use/implement an helper function such as :py:func:`~smrt.inputs.make_soil.make_soil`. This function is able to 
-automatically load a specific soil model .
+To create a substrate, use or implement a helper function such as smrt.inputs.make_soil.make_soil. This function is able to automatically load a specific soil model.
 
-Examples::
-
+Examples:
+    ```python
     from smrt import make_soil
     soil = make_soil("soil_wegmuller", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100, roughness_rms=1e-2)
+    ```
 
-It is recommended to read first the documentation of :py:func:`~smrt.inputs.make_soil.make_soil` and then explore the different types of soil
-models.
+It is recommended to first read the documentation of smrt.inputs.make_soil.make_soil and then explore the different types of soil models.
 
 .. admonition::  **For developers**
 

--- a/smrt/substrate/flat.py
+++ b/smrt/substrate/flat.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 
-
 """
-Implement the flat interface boundary for the bottom layer (substrate). The reflection and transmission
-are computed using the Fresnel coefficients. This model does not take any specific parameter.
+Implements the flat interface boundary for the bottom layer (substrate).
 
+The reflection and transmission are computed using the Fresnel coefficients. This model does not take any specific parameter.
 """
 
 # local import

--- a/smrt/substrate/geometrical_optics.py
+++ b/smrt/substrate/geometrical_optics.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-
 """
-Implement the geometrical optics rough substrate. See the documentation in :py:mod:`~smrt.interface.geometrical_optics`
+Implements the geometrical optics rough substrate.
 
+See the documentation in smrt.interface.geometrical_optics.
 """
 
 # local import

--- a/smrt/substrate/geometrical_optics_backscatter.py
+++ b/smrt/substrate/geometrical_optics_backscatter.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-
 """
-Implement the geometrical optics rough substrate. See the documentation in :py:mod:`~smrt.interface.geometrical_optics_backscatter`.
+Implements the geometrical optics rough substrate.
 
+See the documentation in smrt.interface.geometrical_optics_backscatter.
 """
 
 # local import

--- a/smrt/substrate/iem_fung92.py
+++ b/smrt/substrate/iem_fung92.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 
-
 """
-Implement the flat interface boundary for the bottom layer (substrate). The reflection and transmission
-are computed using the Fresnel coefficients. This model does not take any specific parameter.
+Implements the flat interface boundary for the bottom layer (substrate).
 
+The reflection and transmission are computed using the Fresnel coefficients. This model does not take any specific parameter.
 """
 
 # local import

--- a/smrt/substrate/iem_fung92_brogioni10.py
+++ b/smrt/substrate/iem_fung92_brogioni10.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-
 """
 Implement the flat interface boundary for the bottom layer (substrate). The reflection and transmission
 are computed using the Fresnel coefficients. This model does not take any specific parameter.

--- a/smrt/substrate/radar_calibration_sphere.py
+++ b/smrt/substrate/radar_calibration_sphere.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 
-
 """
-Implement the radar_calibration_sphere interface boundary for the bottom layer (substrate).
-
+Implements the radar_calibration_sphere interface boundary for the bottom layer (substrate).
 """
 
 # local import

--- a/smrt/substrate/reflector.py
+++ b/smrt/substrate/reflector.py
@@ -1,35 +1,35 @@
 # coding: utf-8
 
-""" Implement a reflective boundary conditions with prescribed reflection coefficient in the specular direction.
+"""
+Implements a reflective boundary condition with prescribed reflection coefficient in the specular direction.
+
 The reflection is set to a value or a function of theta. Azimuthal symmetry is assumed (no dependence on phi).
 
-The `specular_reflection` parameter can be a scalar, a function or a dictionary.
+Args:
+    specular_reflection: Can be a scalar, a function, or a dictionary.
+        - scalar: Uses the same reflection for all angles.
+        - function: Takes a single argument theta array (in radians) and returns the reflection as an array of the same size as theta.
+        - dictionary: Keys must be 'H' and 'V', and values are a scalar or a function, interpreted as for the non-polarized case.
 
-    - scalar: same reflection is use for all angles
-    - function: the function must take a unique argument theta array (in radians) and return the reflection as an array of the same size as theta
-    - dictionary: in this case, the keys must be 'H' and 'V' and the values are a scalar or a function and are interpreted as for the non-polarized case.
-
-To make a reflector, it is recommended to use the helper function :py:func:`~smrt.substrate.reflector.make_reflector`.
-
+Returns:
+    Reflector: A reflector instance.
 
 Examples::
 
     # the full path import is required
     from smrt.substrate.reflector import make_reflector
 
-    # return a perfect reflector (the temperature is useless in this specific case)
+    # Returns a perfect reflector (the temperature is useless in this specific case)
     ref = make_reflector(temperature=260, specular_reflection=1)
 
-    # return a perfect absorber / black body.
+    # Returns a perfect absorber / black body.
     ref = make_reflector(temperature=260, specular_reflection=0)
 
     # Specify a frequency and polarization dictionary of reflectivity
     ref = make_reflector(specular_reflection={(21e9, 'H'): 0.5, (21e9, 'V'): 0.6, (36e9, 'H'): 0.7, (36e9, 'V'): 0.8})
-
-.. note::
-
-    the backscatter coefficient argument is not implemented/documented yet.
-
+    
+Note:
+    The backscatter coefficient argument is not implemented or documented yet.
 """
 
 import numpy as np

--- a/smrt/substrate/reflector_backscatter.py
+++ b/smrt/substrate/reflector_backscatter.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 
-""" Implement a reflective boundary conditions with prescribed reflection coefficient in the specular direction, and backscatter coefficient.
+"""
+Implements a reflective boundary condition with prescribed reflection coefficient in the specular direction and backscatter coefficient.
+
 The reflection is set to a value or a function of theta. Azimuthal symmetry is assumed (no dependence on phi).
 
 The `specular_reflection` parameter can be a scalar, a function or a dictionary.
@@ -21,23 +23,21 @@ Examples::
     # the full path import is required
     from smrt.substrate.reflector import make_reflector
 
-    # return a perfect reflector (the temperature is useless in this specific case)
+    # Returns a perfect reflector (the temperature is useless in this specific case)
     ref = make_reflector(temperature=260, specular_reflection=1)
 
-    # return a perfect absorber / black body.
+    # Returns a perfect absorber / black body.
     ref = make_reflector(temperature=260, specular_reflection=0)
 
-    # use a function as a function of the cosine of the incidence angle
-
+    # Use a function as a function of the cosine of the incidence angle
     def reflection_function(mu):
         return 0.5 * mu
 
     ref = make_reflector(specular_reflection=reflection_function)
+    ```
 
-.. note::
-
-    the backscatter coefficient argument is not implemented/documented yet.
-
+Note:
+    The backscatter coefficient argument is not implemented or documented yet. Modeling substrate with prescribed backscatter value with the DORT solver is an approximate trick, and the result is only approximately the prescribed value even for a transparent snowpack.
 """
 
 import numpy as np

--- a/smrt/substrate/reflector_backscatter.py
+++ b/smrt/substrate/reflector_backscatter.py
@@ -34,7 +34,6 @@ Examples::
         return 0.5 * mu
 
     ref = make_reflector(specular_reflection=reflection_function)
-    ```
 
 Note:
     The backscatter coefficient argument is not implemented or documented yet. Modeling substrate with prescribed backscatter value with the DORT solver is an approximate trick, and the result is only approximately the prescribed value even for a transparent snowpack.

--- a/smrt/substrate/rough_choudhury79.py
+++ b/smrt/substrate/rough_choudhury79.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
-"""Implement the rough boundary reflectivity presented in Choudhury et al. (1979). It is not suitable for the active mode.
+"""
+Implements the rough boundary reflectivity presented in Choudhury et al. (1979).
 
-Applicable for ksigma<<1
+This model is not suitable for the active mode and is applicable for ksigma << 1.
 
-parameters: roughness_rms
+Args:
+    roughness_rms: The root mean square of the surface roughness.
 
 """
 

--- a/smrt/substrate/soil_qnh.py
+++ b/smrt/substrate/soil_qnh.py
@@ -1,16 +1,22 @@
 # coding: utf-8
 
-"""Implement the QNH soil model proposed by Wang, 1983.  This model is for the passive mode, it is
-not suitable for the active mode.
+"""
+Implements the QNH soil model proposed by Wang, 1983.
 
-parameters: Q, N, H  (or Nv and Nh instead of N)
+This model is for the passive mode and is not suitable for the active mode.
 
-Q and N are set to zero by default. The roughness rms is called H and is a required parameter (note: it is called roughness_rms in soil_wegmuller)
+Args:
+    Q: Optional; default is 0.
+    N: Optional; default is 0.
+    Nv: Optional; default is NaN.
+    Nh: Optional; default is NaN.
+    H: Required; the roughness rms (note: called roughness_rms in soil_wegmuller).
 
 Examples:
+    ```python
     soil = make_soil("soil_qnh", "dobson85", moisture=0.2, sand=0.4, clay=0.3, drymatter=1100,
-                    Q=0, N=0, H=1e-2)
-
+                     Q=0, N=0, H=1e-2)
+    ```
 """
 
 import numpy as np

--- a/smrt/substrate/soil_wegmuller.py
+++ b/smrt/substrate/soil_wegmuller.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
-"""Implement the empirical soil model presented in Wegmuller and Maetzler 1999. 
-It is often used in microwave radiometry. It is not suitable for the active mode.
+"""
+Implements the empirical soil model presented in Wegmuller and Maetzler 1999.
 
-parameters: roughness_rms
+This model is often used in microwave radiometry. It is not suitable for the active mode.
+
+Args:
+    roughness_rms: The root mean square of the surface roughness.
 
 """
 

--- a/smrt/substrate/transparent.py
+++ b/smrt/substrate/transparent.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-
 """
-Implement the geometrical optics rough substrate. See the documentation in :py:mod:`~smrt.interface.geometrical_optics_backscatter`.
+Implements the geometrical optics rough substrate.
 
+See the documentation in smrt.interface.geometrical_optics_backscatter.
 """
 
 # local import

--- a/smrt/utils/__init__.py
+++ b/smrt/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-This packages contain various utilities that works with/for SMRT.
+Contains various utilities that work with/for SMRT.
 
 The wrappers to legacy snow radiative transfer models can be used to run DMRT-QMS (passive mode), HUT and MEMLS (passive mode).
 Other tools are listed below.
@@ -12,11 +12,26 @@ LOG10 = np.log(10.)
 
 
 def dB(x):
-    """Compute the ratio x in dB. Any small value is converted to -200dB.
+    """
+    Computes the ratio x in dB. Any small value is converted to -200dB.
+
+    Args:
+        x: Input value or array.
+
+    Returns:
+        The value(s) in dB.
     """
     return 10 * np.log(np.maximum(x, 1e-20)) / LOG10
 
 
 def invdB(x):
-    """computes the dB value x in natural value."""
+    """
+    Computes the dB value x in natural value.
+
+    Args:
+        x: Value(s) in dB.
+
+    Returns:
+        The value(s) in natural units.
+    """
     return 10 ** (x / 10.0)

--- a/smrt/utils/dmrt_qms_legacy.py
+++ b/smrt/utils/dmrt_qms_legacy.py
@@ -1,16 +1,16 @@
 # coding: utf-8
 
-""" Wrapper to the original DMRT_QMS matlab code using the SMRT framework. To use this module, extra installation are needed:
+"""
+Wraps the original DMRT_QMS matlab code using the SMRT framework.
 
- * get DMRT_QMS from http://web.eecs.umich.edu/~leutsang/Available%20Resources.html and extract the model somewhere
+To use this module, extra installations are needed:
 
- * install the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py`
+    * Gets DMRT_QMS from http://web.eecs.umich.edu/~leutsang/Available%20Resources.html and extracts the model somewhere.
+    * Installs the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py`.
+    * Installs Octave version 3.6 or above.
+    * For convenience, sets the DMRT_QMS_DIR environment variable to point to DMRT-QMS path. This path can also be programmatically set with and use :py:func:`set_dmrt_qms_path` function.
 
- * install Octave version 3.6 or above.
-
- * for convenience you can set the DMRT_QMS_DIR environment variable to point to DMRT-QMS path. This path can also be programmatically set with and use :py:func:`set_dmrt_qms_path` function.
-
-In case of problem check the instructions given in http://blink1073.github.io/oct2py/source/installation.html
+In case of problem, checks the instructions given in http://blink1073.github.io/oct2py/source/installation.html.
 
 You may also want to increase the number of streams in passive/DMRT_QMS_passive.m
 
@@ -35,7 +35,12 @@ _dmrt_qms_path = None
 
 
 def set_dmrt_qms_path(path):
-    """set the path where dmrt_qms archive has been uncompressed, i.e. where the file `dmrt_qmsmain.m` is located."""
+    """
+    Sets the path where dmrt_qms archive has been uncompressed, i.e. where the file `dmrt_qmsmain.m` is located.
+
+    Args:
+        path: Path to the DMRT_QMS directory.
+    """
     global _dmrt_qms_path
 
     if path != _dmrt_qms_path:
@@ -55,13 +60,20 @@ except KeyError:
 
 
 def run(sensor, snowpack, dmrt_qms_path=None, snowpack_dimension=None, full_output=False):
-    """call DMRT-QMS for the snowpack and sensor configuration given as argument. The :py:mod:`~smrt.microstructure_model.sticky_hard_spheres` microstructure model 
+    """
+    Calls DMRT-QMS for the snowpack and sensor configuration given as argument. The :py:mod:`~smrt.microstructure_model.sticky_hard_spheres` microstructure model 
     must be used.
 
-    :param snowpack: describe the snowpack.
-    :param sensor: describe the sensor configuration.
-    :param full_output: determine if ks, ka and effective permittivity are return in addition to the result object
-"""
+    Args:
+        sensor: Sensor configuration.
+        snowpack: Snowpack description.
+        dmrt_qms_path: Optional path to DMRT_QMS.
+        snowpack_dimension: Optional dimension for results when a list of snowpacks is provided.
+        full_output: If True, returns ks, ka, and effective permittivity in addition to the result object.
+
+    Returns:
+        PassiveResult or tuple with additional outputs if full_output is True.
+    """
 
     if dmrt_qms_path is not None:
         set_dmrt_qms_path(dmrt_qms_path)
@@ -162,11 +174,17 @@ def dmrt_qms_active(sensor, snowpack):
 
 
 def dmrt_qms_emmodel(sensor, layer, dmrt_qms_path=None):
-    """ Compute scattering and absorption coefficients using DMRT QMS
+    """
+    Computes scattering and absorption coefficients using DMRT QMS.
 
-        :param layer: describe the layer.
-        :param sensor: describe the sensor configuration.
-"""
+    Args:
+        sensor: Sensor configuration.
+        layer: Layer description.
+        dmrt_qms_path: Optional path to DMRT_QMS.
+
+    Returns:
+        namedtuple with ks and ka.
+    """
 
     diameter = np.float64([layer.microstructure.radius * 200])
     density = np.float64([layer.frac_volume * DENSITY_OF_ICE / 1000])

--- a/smrt/utils/hut_legacy.py
+++ b/smrt/utils/hut_legacy.py
@@ -1,18 +1,17 @@
 # coding: utf-8
 
-""" Wrapper to original HUT matlab using SMRT framework. To use this module, extra installation are needed:
+"""
+Wraps the original HUT matlab using SMRT framework.
 
- * get HUT. Decompress the archive somewhere on your disk.
+To use this module, extra installations are needed:
 
- * in the file snowemis_nlayers change the 6 occurences of the "do" variable into "dos" because it causes a syntax error in Octave.
+    * Gets HUT. Decompresses the archive somewhere on your disk.
+    * In the file snowemis_nlayers, changes the 6 occurrences of the "do" variable into "dos" because it causes a syntax error in Octave.
+    * Installs the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py`.
+    * Installs Octave version 3.6 or above.
+    * For convenience, sets the HUT_DIR environment variable to point to HUT path. This path can also be programmatically set with :py:func:`set_hut_path`.
 
- * install the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py`.
-
- * install Octave version 3.6 or above.
-
- * for convenience you can set the HUT_DIR environment variable to point to HUT path. This path can also be programmatically set with :py:func:`set_hut_path`.
-
- In case of problem check the instructions given in http://blink1073.github.io/oct2py/source/installation.html
+In case of problem, checks the instructions given in http://blink1073.github.io/oct2py/source/installation.html.
 
 """
 
@@ -31,7 +30,12 @@ _hut_path = None
 
 
 def set_hut_path(path):
-    """set the path where MEMLS archive has been uncompressed, i.e. where the file `memlsmain.m` is located."""
+    """
+    Sets the path where HUT archive has been uncompressed, i.e. where the file `memlsmain.m` is located.
+
+    Args:
+        path: Path to the HUT directory.
+    """
     global _hut_path
 
     if path != _hut_path:
@@ -48,14 +52,19 @@ except KeyError:
 
 
 def run(sensor, snowpack, ke_option=0, grainsize_option=1, hut_path=None):
-    """call HUT for the snowpack and sensor configuration given as argument. Any microstructure model that defines the "radius" parameter
-    is valid.
+    """
+    Calls HUT for the snowpack and sensor configuration given as argument. Any microstructure model that defines the "radius" parameter is valid.
 
-    :param snowpack: describe the snowpack.
-    :param sensor: describe the sensor configuration.
-    :param ke_option: see HUT snowemis_nlayers.m code
-    :param grainsize_option: see HUT snowemis_nlayers.m code
-"""
+    Args:
+        sensor: Sensor configuration.
+        snowpack: Snowpack description.
+        ke_option: Option for HUT snowemis_nlayers.m code.
+        grainsize_option: Option for HUT snowemis_nlayers.m code.
+        hut_path: Optional path to HUT.
+
+    Returns:
+        Result object.
+    """
 
     if hut_path is not None:
         set_hut_path(hut_path)

--- a/smrt/utils/memls_legacy.py
+++ b/smrt/utils/memls_legacy.py
@@ -1,16 +1,16 @@
 # coding: utf-8
 
-""" Wrapper to the original MEMLS matlab code using the SMRT framework. To use this module, extra installation are needed:
+"""
+Wraps the original MEMLS matlab code using the SMRT framework.
 
- * download MEMLS from http://www.iapmw.unibe.ch/research/projects/snowtools/memls.html. Decompress the archive somewhere on your disk.
+To use this module, extra installations are needed:
 
- * install the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py` 
+    * Downloads MEMLS from http://www.iapmw.unibe.ch/research/projects/snowtools/memls.html. Decompresses the archive somewhere on your disk.
+    * Installs the oct2py module using :code:`pip install oct2py` or :code:`easy_install install oct2py`.
+    * Installs Octave version 3.6 or above.
+    * For convenience, sets the MEMLS_DIR environment variable to point to MEMLS path. This path can also be programmatically set with :py:func:`set_memls_path`.
 
- * install Octave version 3.6 or above.
-
- * for convenience you can set the MEMLS_DIR environment variable to point to MEMLS path. This path can also be programmatically set with :py:func:`set_memls_path`
-
- In case of problem check the instructions given in http://blink1073.github.io/oct2py/source/installation.html
+In case of problem, checks the instructions given in http://blink1073.github.io/oct2py/source/installation.html.
 
 """
 
@@ -38,7 +38,12 @@ MEMLS_RECOMMENDED = 11
 _memls_path = None
 
 def set_memls_path(path):
-    """set the path where MEMLS archive has been uncompressed, i.e. where the file `memlsmain.m` is located."""
+    """
+    Sets the path where MEMLS archive has been uncompressed, i.e. where the file `memlsmain.m` is located.
+
+    Args:
+        path: Path to the MEMLS directory.
+    """
     global _memls_path
 
     if path != _memls_path:
@@ -56,8 +61,8 @@ except KeyError:
 
 
 def run(sensor, snowpack, scattering_choice=ABORN, atmosphere=None, memls_path=None, memls_driver=None, snowpack_dimension=None):
-    """ call MEMLS for the snowpack and sensor configuration given as argument. Any microstructure model that defines the "corr_length" parameter
-        is valid, but it must be clear that MEMLS only considers exponential autocorrelation.
+    """
+    Calls MEMLS for the snowpack and sensor configuration given as argument. Any microstructure model that defines the "corr_length" parameter is valid, but it must be clear that MEMLS only considers exponential autocorrelation.
 
         :param snowpack: describe the snowpack.
         :param sensor: describe the sensor configuration.

--- a/smrt/utils/repo_tools.py
+++ b/smrt/utils/repo_tools.py
@@ -1,27 +1,32 @@
-""" General tools related to code repository """
+""" 
+Provides general tools related to the code repository.
+"""
 
-# Way to print out mercurical commit number
+# Way to print out mercurial commit number
 # See http://stackoverflow.com/questions/1153469/mercurial-scripting-with-python
 import subprocess
 
 
 def get_hg_rev(file_path):
     """
-    get_hg_rev is a tool to print out which commit of the model you are using.
+    Gets the mercurial commit ID of the model you are using.
 
-    This is useful when revisiting ipython notebooks, can be used to compare the original
+    This is useful when revisiting ipython notebooks, and can be used to compare the original
     model commit ID with the latest version.
 
-    **Usage**::
-
+    Usage:
         from smrt.utils.repo_tools import get_hg_rev
         path_to_file = "/path/to/your/repository"
         get_hg_rev(path_to_file)
 
-    .. Note::
+    Note:
+        This is for a mercurial repository.
 
-        This is for a mercurial repository
+    Args:
+        file_path: Path to the repository.
 
+    Returns:
+        The commit ID as bytes.
     """
     pipe = subprocess.Popen(
         ["hg", "id", "-i", "-R", file_path],

--- a/smrt/utils/rough_surface_validity.py
+++ b/smrt/utils/rough_surface_validity.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from collections.abc import Iterable
 
@@ -10,15 +9,21 @@ import matplotlib.pyplot as plt
 colors = {'kirchoff': '#87CEEB', 'IEM': '#FF6F61', 'SPM': '#32CD32', 'SSA': '#FFD700', 'GO': '#708090'}
 
 def validity_diagram(sensor=None, snowpack=None, interface=None, rms_height=None, correlation_length=None, frequency=None, ax=None):
-    """plot a validity diagram for the rough surface model (assuming a Gaussian surface) with the roughness of the
+    """
+    Plots a validity diagram for the rough surface model (assuming a Gaussian surface) with the roughness of the
     snowpack (and/or the interface, or provides RMS and correlation values).
 
-    :param sensor: sensor with a single or multiple frequencies.
-    :param snowpack: snowpack from which to take the interfaces.
-    :param interface: an interface or a list of interfaces (can be a substrate as well).
-    :param rms_height: other rms_height to be plotted.
-    :param correlation_length: other correlation_length to be plotted.
-    :param frequency: frequency if the sensor is not provided.
+    Args:
+        sensor: Sensor with a single or multiple frequencies.
+        snowpack: Snowpack from which to take the interfaces.
+        interface: An interface or a list of interfaces (can be a substrate as well).
+        rms_height: Other rms_height to be plotted.
+        correlation_length: Other correlation_length to be plotted.
+        frequency: Frequency if the sensor is not provided.
+        ax: Matplotlib axis.
+
+    Returns:
+        None.
     """
 
     if ax is None:


### PR DESCRIPTION
The docstrings in the 'smrt' folder have been automatically convert from ReST to Google style, with proofreading.

Some docstrings have been missed by the automatic conversion and are thus still in ReST.

More important: a few conversions have caused some problems in the documentation, and some may have been missed during proofreading. Issues include:
- bad reference to a function or module (:py:func: may have been changed to :py:mod: or deleted)
- bad code highlighting (suppressed double colon)
- deleted note blocks (deletion of the ..admonition:: command)

These issues do not cause great trouble and no content has disappeared. When noticed in the future, they can easily be fixed by hand.