### PR TITLE
Multifresnel substrate modification

### DIFF
--- a/smrt/rtsolver/dort.py
+++ b/smrt/rtsolver/dort.py
@@ -638,8 +638,8 @@ class DORT(object):
         if self.snowpack.substrate is None and optical_depth < 5:
             smrt_warn(
                 "DORT has detected that the snowpack is optically shallow (tau=%g) and no substrate has been set, meaning that the space "
-                "under the snowpack is vaccum and that the snowpack is shallow enough to affect the signal measured at the surface."
-                "This is usually not wanted. Either increase the thickness of the snowpack or set a substrate."
+                "under the snowpack is 'empty' with snowpack shallow enough to affect the measured signal at the surface."
+                "This is usually not wanted and can produce wrong results. Either increase the thickness of the snowpack or set a substrate."
                 " If wanted, add a transparent substrate to supress this warning" % optical_depth
             )
 

--- a/smrt/rtsolver/multifresnel/multifresnel.py
+++ b/smrt/rtsolver/multifresnel/multifresnel.py
@@ -60,9 +60,9 @@ def compute_matrix_slab(
     eps_1 = air_permittivity
 
     M = None
-    min_optical_depth = 0.
+    tau_snowpack = 0.
     for eps_2, temperature_, kd_ in zip(permittivity, temperature, kd):
-        L, (mu2, tau) = forward_matrix_fulloutput(
+        L, (mu2, tau_layer) = forward_matrix_fulloutput(
             eps_1,
             eps_2,
             mu,
@@ -73,15 +73,15 @@ def compute_matrix_slab(
 
         M = matmul3(M, L) if M is not None else L
 
-        tau_max -= tau  # decrease the optical depth
-        min_optical_depth += np.min(tau)
+        tau_max -= tau_layer  # decrease the optical depth
+        tau_snowpack += tau_layer[imumax]
         
         if tau_max[imumax] < 0:
             break
 
         mu = mu2
         eps_1 = eps_2
-    return M, min_optical_depth
+    return M, tau_snowpack
 
 
 def forward_matrix(

--- a/smrt/rtsolver/multifresnel/multifresnel.py
+++ b/smrt/rtsolver/multifresnel/multifresnel.py
@@ -60,6 +60,7 @@ def compute_matrix_slab(
     eps_1 = air_permittivity
 
     M = None
+    min_optical_depth = 0.
     for eps_2, temperature_, kd_ in zip(permittivity, temperature, kd):
         L, (mu2, tau) = forward_matrix_fulloutput(
             eps_1,
@@ -73,12 +74,14 @@ def compute_matrix_slab(
         M = matmul3(M, L) if M is not None else L
 
         tau_max -= tau  # decrease the optical depth
+        min_optical_depth += np.min(tau)
+        
         if tau_max[imumax] < 0:
             break
 
         mu = mu2
         eps_1 = eps_2
-    return M
+    return M, min_optical_depth
 
 
 def forward_matrix(

--- a/smrt/rtsolver/multifresnel_thermalemission.py
+++ b/smrt/rtsolver/multifresnel_thermalemission.py
@@ -114,7 +114,7 @@ class MultiFresnelThermalEmission(object):
 
         mu = np.cos(sensor.theta)
 
-        M, min_optical_depth = compute_matrix_slab(
+        M, tau_snowpack = compute_matrix_slab(
             frequency=sensor.frequency,
             outmu=mu,
             permittivity=effective_permittivity,
@@ -123,12 +123,12 @@ class MultiFresnelThermalEmission(object):
             prune_deep_snowpack=self.prune_deep_snowpack,
         )
 
-        if min_optical_depth < 5 and snowpack.substrate is None :
+        if tau_snowpack < 5 and snowpack.substrate is None :
             smrt_warn(
                 "Multifresnel has detected that the snowpack is optically shallow (tau=%g) and no substrate has been set, meaning that the space "
                 "under the snowpack is 'empty' with snowpack shallow enough to affect the measured signal at the surface."
                 "This is usually not wanted and can produce wrong results. Either increase the thickness of the snowpack or set a substrate."
-                " If wanted, add a transparent substrate to supress this warning" % min_optical_depth
+                " If wanted, add a transparent substrate to supress this warning" % tau_snowpack
             )
 
         Tbv, Tbh = compute_emerging_radiation(M)

--- a/smrt/rtsolver/multifresnel_thermalemission.py
+++ b/smrt/rtsolver/multifresnel_thermalemission.py
@@ -110,7 +110,7 @@ class MultiFresnelThermalEmission(object):
             if effective_permittivity[-1].imag < 1e-8:
                 smrt_warn("the permittivity of the substrate has a too small imaginary part for reliable results")
             thickness.append(1e10)  # add an infinite layer (hugly hack)
-            temperature.append(snowpack.substrate.temperature)
+            temperature = np.append(temperature, snowpack.substrate.temperature)
 
         mu = np.cos(sensor.theta)
 
@@ -137,6 +137,6 @@ class MultiFresnelThermalEmission(object):
         coords = [("theta", sensor.theta_deg), ("polarization", ["V", "H"])]
 
         # store other diagnostic information
-        other_data = prepare_kskaeps_profile_information(snowpack, emmodels, effective_permittivity, mu=mu)
+        other_data = prepare_kskaeps_profile_information(snowpack, emmodels, effective_permittivity[0:snowpack.nlayers], mu=mu)
 
         return make_result(sensor, np.transpose((Tbv, Tbh)), coords, other_data=other_data)

--- a/smrt/rtsolver/multifresnel_thermalemission.py
+++ b/smrt/rtsolver/multifresnel_thermalemission.py
@@ -114,7 +114,7 @@ class MultiFresnelThermalEmission(object):
 
         mu = np.cos(sensor.theta)
 
-        M = compute_matrix_slab(
+        M, min_optical_depth = compute_matrix_slab(
             frequency=sensor.frequency,
             outmu=mu,
             permittivity=effective_permittivity,
@@ -122,6 +122,14 @@ class MultiFresnelThermalEmission(object):
             thickness=thickness,
             prune_deep_snowpack=self.prune_deep_snowpack,
         )
+
+        if min_optical_depth < 5 and snowpack.substrate is None :
+            smrt_warn(
+                "Multifresnel has detected that the snowpack is optically shallow (tau=%g) and no substrate has been set, meaning that the space "
+                "under the snowpack is 'empty' with snowpack shallow enough to affect the measured signal at the surface."
+                "This is usually not wanted and can produce wrong results. Either increase the thickness of the snowpack or set a substrate."
+                " If wanted, add a transparent substrate to supress this warning" % min_optical_depth
+            )
 
         Tbv, Tbh = compute_emerging_radiation(M)
 


### PR DESCRIPTION
Hello,

This PR addresses three improvements related to the multifresnel solver and dort warning:

1. Warning Clarity: Corrected the misleading "void space" warning for optically shallow snowpacks to clarify it refers to missing lower ice boundaries in dort.py.

2. Substrate Bug Fix: Resolved an existing bug in multifresnel that was causing crash with substrate.

3. New Warning: Added a new, dedicated warning within multifresnel for optically shallow snowpack conditions.