### PR TITLE
Configure benchmarks for local use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ ENV/
 *.patch
 # pixi environments
 .pixi
+# Benchmark results
+results

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-benchmarks
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,170 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+    // The name of the project being benchmarked
+    "project": "smrt",
+    // The project's homepage
+    "project_url": "https://smrt-model.science/",
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+    // Customizable commands for building the project.
+    // See asv.conf.json documentation.
+    // To build the package using pyproject.toml (PEP518), uncomment the following lines
+    "build_command": [
+        "python -m pip install build",
+        "python -m build",
+        "python -mpip wheel --no-deps -w {build_cache_dir} {build_dir}"
+    ],
+    // To build the package using setuptools and a setup.py file, uncomment the following lines
+    // "build_command": [
+    //     "python setup.py build",
+    //     "python -mpip wheel -w {build_cache_dir} {build_dir}"
+    // ],
+    // Customizable commands for installing and uninstalling the project.
+    // See asv.conf.json documentation.
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // List of branches to benchmark. If not provided, defaults to "main"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["main"], // for git
+    // "branches": ["default"],    // for mercurial
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv", "mamba" (above 3.8)
+    // or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/smrt-model/smrt/commit/",
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.8", "3.12"],
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    // "matrix": {
+    //     "req": {
+    //         "numpy": ["1.6", "1.7"],
+    //         "six": ["", null],  // test with and without six installed
+    //         "pip+emcee": [""]   // emcee is only available for install with pip.
+    //     },
+    //     "env": {"ENV_VAR_1": ["val1", "val2"]},
+    //     "env_nobuild": {"ENV_VAR_2": ["val3", null]},
+    // },
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    // "include": [
+    //     // additional env for python3.12
+    //     {"python": "3.12", "req": {"numpy": "1.26"}, "env_nobuild": {"FOO": "123"}},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "3.12", "req": {"libpython": ""}},
+    // ],
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    // "env_dir": "env",
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    // "results_dir": "results",
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    // "html_dir": "html",
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/benchmarks/local_benchmarks.py
+++ b/benchmarks/local_benchmarks.py
@@ -1,0 +1,106 @@
+from smrt.inputs.make_medium import make_snowpack
+from smrt import sensor_list, make_model
+from smrt.rtsolver.dort import DORT
+from smrt.inputs.sensor_list import amsre
+from smrt.core.model import Model
+import numpy as np
+from smrt.microstructure_model.sticky_hard_spheres import StickyHardSpheres
+from smrt.core.error import SMRTWarning
+import warnings
+
+class Multiple_Snowpacks:
+    """
+    Benchmark time and peak memory for creating multiple snowpacks and running model in parrallel
+
+    Inspired from smrt/test/test_model.py
+    """
+    param_names = ["snowpack_amount"]
+    params = [1000] #Add values for multiple benchmarks
+    def setup(self, n):
+        """
+        Initiates snowpacks, model and sensor for the benchmarks
+        """
+        self.temperatures = np.linspace(200, 270, n)
+        self.snowpack_list = [make_snowpack([2000], StickyHardSpheres, density=[250], temperature=t,
+                                            radius=0.3e-3, stickiness=0.2) for t in self.temperatures]
+        self.m = Model('dmrt_qcacp_shortrange', DORT)
+        self.sensor = amsre()
+
+    def time_setup(self, n):
+        """
+        Benchmark time for creating snowpack list
+        """
+        [make_snowpack([2000], StickyHardSpheres, density=[250], temperature=t,
+                                            radius=0.3e-3, stickiness=0.2) 
+                                            for t in self.temperatures]
+        
+    def peakmem_setup(self, n):
+        """
+        Benchmark memory usage for creating snowpack list
+        """
+        [make_snowpack([2000], StickyHardSpheres, density=[250], temperature=t,
+                                            radius=0.3e-3, stickiness=0.2)
+                                            for t in self.temperatures]
+
+    def time_parrallel_run(self, n):
+        """
+        Benchmark time for running model
+        """
+        self.m.run(self.sensor, self.snowpack_list, parallel_computation=True)
+
+    def peakmem_parrallel_run(self, n):
+        """
+        Benchmark memory usage for running model
+        """
+        self.m.run(self.sensor, self.snowpack_list, parallel_computation=True)
+
+class Large_Snowpack:
+    """
+    Benchmark time and peak memory for creating a large snowpack and running model
+
+    Inspired from smrt/test/test_coherent_layer.py
+    """
+    param_names = ["layer_amount"]
+    params = [600] #Add values for multiple benchmarks
+    def setup(self, layer_amount):
+        """
+        Initiates snowpack, model and sensor for the benchmarks
+        """
+         # this test is only here to avoid regression, it is not scientifically validated
+
+        self.density = np.linspace(300, 916.7, layer_amount)
+        self.thickness = np.ones(layer_amount) * 3000 / layer_amount
+        self.temperature = np.linspace(200, 270, layer_amount)
+        self.corr_length = np.ones(layer_amount) *200e-6
+        theta = 60
+        self.radiometer = sensor_list.passive(5e9, theta)
+        self.sp = make_snowpack(self.thickness, "exponential", density=self.density,
+                                temperature=self.temperature, corr_length=self.corr_length)
+        # create the EM Model - Equivalent DMRTML
+        self.m = make_model("iba", "dort", rtsolver_options={"n_max_stream": 64, "process_coherent_layers": True})
+        warnings.simplefilter("ignore", category=SMRTWarning)
+
+    def time_setup(self, layer_amount):
+        """
+        Benchmark time for creating snowpack list
+        """
+        make_snowpack(self.thickness, "exponential", density=self.density, temperature=self.temperature, corr_length=self.corr_length)
+        
+    def peakmem_setup(self, layer_amount):
+        """
+        Benchmark memory usage for creating snowpack list
+        """
+        make_snowpack(self.thickness, "exponential", density=self.density,
+                      temperature=self.temperature, corr_length=self.corr_length)
+
+    def time_parrallel_run(self, layer_amount):
+        """
+        Benchmark time for running model
+        """
+        self.m.run(self.radiometer, self.sp, parallel_computation=True)
+
+    def peakmem_parrallel_run(self, layer_amount):
+        """
+        Benchmark memory usage for running model
+        """
+        self.m.run(self.radiometer, self.sp, parallel_computation=True)

--- a/doc/source/developer/developer_howto.rst
+++ b/doc/source/developer/developer_howto.rst
@@ -46,6 +46,14 @@ Bug Correction
 
 Every bug found and corrected should result in writing a unit test to prevent the bug from reappearing (regression).
 
+Benchmarking
+------------
+Benchmarking is done with `Airspeed Velocity (ASV) <https://asv.readthedocs.io/en/stable/index.html>`_ which should be installed as a dependency for developers. Benchmarks can be run with
+```bash
+asv run
+```
+Running ASV for the first time on a machine will ask for information on the machine. For now, benchmark results are not saved and only local comparisons can be done. Feel free to add any nuseful benchmarks.
+
 Documentation Generation with Sphinx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Configure [https://asv.readthedocs.io/en/stable/index.html](Arispeed Velocity) (ASV) with two benchmarks suites:
- A large list of small snowpacks
- A large snowpack
Both suites create the snowpacks and model and test time and memory usage for creating and using the snowpacks. A parameter is given for the size of the test (taking ~10s currently).

The benchmarks are inspired from tests and the inputs may not be the most suitable.

Run the benchmarks from root with "asv run"