### PR TITLE
Fix bedrock permittivity

### DIFF
--- a/smrt/permittivity/bedrock.py
+++ b/smrt/permittivity/bedrock.py
@@ -25,7 +25,7 @@ from smrt.core.globalconstants import PERMITTIVITY_OF_FREE_SPACE
 from smrt.core.layer import layer_properties
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_granite_hartlieb16(frequency):
     """Hartlieb et al. (2016) 10.1016/j.mineng.2015.11.008
     Frequency = 2450 MHz, temperature = 20 degC
@@ -33,7 +33,7 @@ def bedrock_permittivity_granite_hartlieb16(frequency):
     return 5.45 + 0.038j
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_basalt_hartlieb16(frequency):
     """Hartlieb et al. (2016) 10.1016/j.mineng.2015.11.008
     Frequency = 2450 MHz, temperature = 20 degC
@@ -41,7 +41,7 @@ def bedrock_permittivity_basalt_hartlieb16(frequency):
     return 7.67 + 0.270j
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_sandstone_hartlieb16(frequency):
     """Hartlieb et al. (2016) 10.1016/j.mineng.2015.11.008
     Frequency = 2450 MHz, temperature = 20 degC
@@ -49,7 +49,7 @@ def bedrock_permittivity_sandstone_hartlieb16(frequency):
     return 7.67 + 0.081j
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_frozen_bedrock_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency = 5e6HZ, temperature = close to 0 degC
@@ -58,7 +58,7 @@ def bedrock_permittivity_frozen_bedrock_tulaczyk20(frequency):
     return 2.7 + 1j * (0.0002 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_saturated_bedrock_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency = Midpoints used, conductivity measurment frequency 0.9 to 25 kHZ,
@@ -68,7 +68,7 @@ def bedrock_permittivity_saturated_bedrock_tulaczyk20(frequency):
     return 9.5 + 1j * (0.0055 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_sandy_till_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency = Midpoint & Upper bound, unclear frequency in paper,
@@ -78,7 +78,7 @@ def bedrock_permittivity_sandy_till_tulaczyk20(frequency):
     return 13.0 + 1j * (0.02 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_fairbanks_silt_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency = 100MHz,
@@ -88,7 +88,7 @@ def bedrock_permittivity_fairbanks_silt_tulaczyk20(frequency):
     return 24.0 + 1j * (0.043 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_clay_bearing_till_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency = Midpoints used, unclear frequency in paper,
@@ -98,7 +98,7 @@ def bedrock_permittivity_clay_bearing_till_tulaczyk20(frequency):
     return 13.0 + 1j * (0.0575 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_clay_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency =  100MHz,
@@ -108,7 +108,7 @@ def bedrock_permittivity_clay_tulaczyk20(frequency):
     return 31.0 + 1j * (0.24 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_marine_clay_tulaczyk20(frequency):
     """Tulaczyk & Foley (2020) 10.5194/tc-14-4495-2020
     Frequency =  Midpoint used, unclear frequency in paper,
@@ -118,7 +118,7 @@ def bedrock_permittivity_marine_clay_tulaczyk20(frequency):
     return 31.0 + 1j * (0.55 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_debris_laden_ice_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -128,7 +128,7 @@ def bedrock_permittivity_debris_laden_ice_christianson16(frequency):
     return 3.1 + 1j * (8.0e-5 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_sand_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -138,7 +138,7 @@ def bedrock_permittivity_sand_christianson16(frequency):
     return 2.6 + 1j * (1.3e-4 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_groundwater_till_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -148,7 +148,7 @@ def bedrock_permittivity_groundwater_till_christianson16(frequency):
     return 36.0 + 1j * (0.037 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_freshwater_till_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -158,7 +158,7 @@ def bedrock_permittivity_freshwater_till_christianson16(frequency):
     return 13.0 + 1j * (2.5e-4 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_frozen_till_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -168,7 +168,7 @@ def bedrock_permittivity_frozen_till_christianson16(frequency):
     return 2.9 + 1j * (3.4e-4 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_frozen_bedrock_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,
@@ -178,7 +178,7 @@ def bedrock_permittivity_frozen_bedrock_christianson16(frequency):
     return 2.7 + 1j * (2.0e-4 / (angular_frequency * PERMITTIVITY_OF_FREE_SPACE))
 
 
-@layer_properties
+@layer_properties()
 def bedrock_permittivity_unfrozen_bedrock_christianson16(frequency):
     """Christianson et al. (2016) 10.1002/2015JF003806
     Frequency =  5MHz,

--- a/smrt/test/test_soil.py
+++ b/smrt/test/test_soil.py
@@ -139,7 +139,7 @@ def test_soil_bedrock():
     soiltemperature = 270
     # Using a bedrock model by its short name
     substrate = make_soil_substrate("flat", "bedrock_permittivity_granite_hartlieb16", temperature=soiltemperature)
-    eps = substrate.permittivity_model(1.41e9, soiltemperature)
+    eps = substrate.permittivity_model(1.41e9)
     assert np.isclose(eps, 5.45 + 0.038j)
 
 
@@ -150,7 +150,7 @@ def test_soil_bedrock_complex():
     substrate = make_soil_substrate(
         "flat", "bedrock_permittivity_frozen_bedrock_tulaczyk20", temperature=soiltemperature
     )
-    eps = substrate.permittivity_model(freq, soiltemperature)
+    eps = substrate.permittivity_model(freq)
 
     expected = 2.7 + 1j * (0.0002 / (2 * np.pi * freq * PERMITTIVITY_OF_FREE_SPACE))
     assert np.isclose(eps, expected)


### PR DESCRIPTION
Correct decorator call, parenthesis were needed.
Update test_soil.py with removal of temperature in permittivity functions.